### PR TITLE
fix: remove SCRIPT_DEBUG

### DIFF
--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -21,7 +21,9 @@
 if (!defined('WPINC')) {
     die;
 }
-define('SCRIPT_DEBUG', true);
+if (!defined('SCRIPT_DEBUG')) {
+	define('SCRIPT_DEBUG', true);
+}
 defined('SMARTLING_DEBUG') || file_exists(__DIR__ . '/smartling.debug') && define('SMARTLING_DEBUG', true);
 /**
  * Execute everything only on admin pages or while running cron tasks

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -21,9 +21,6 @@
 if (!defined('WPINC')) {
     die;
 }
-if (!defined('SCRIPT_DEBUG')) {
-	define('SCRIPT_DEBUG', true);
-}
 defined('SMARTLING_DEBUG') || file_exists(__DIR__ . '/smartling.debug') && define('SMARTLING_DEBUG', true);
 /**
  * Execute everything only on admin pages or while running cron tasks


### PR DESCRIPTION
To avoid throwing PHP notices when other plugins or config already define `SCRIPT_DEBUG`, its definition should be tested before calling `define()`.

I disagree with hardcoding this to true if it's not already explicitly defined on live sites as well - is there a good reason to force worse performance on users?