### PR TITLE
Changed the way that Gutenberg detection happens. Gutenberg can be fa…

### DIFF
--- a/inc/Smartling/WP/View/ContentEditJob.php
+++ b/inc/Smartling/WP/View/ContentEditJob.php
@@ -322,7 +322,11 @@ if ($post instanceof WP_Post) {
                 minDate: 0
             });
 
-            if (window.React) {
+            /*
+            * Use class checking method for detecting Gutenberg as defined here https://github.com/WordPress/gutenberg/issues/12200
+            * This prevents conflicts with plugins that enqueue the React library when the Classic Editor is enabled.
+            */
+            if (document.body.classList.contains( 'block-editor-page' )) {
                 var hasProp = function(obj, prop) {
                     return Object.prototype.hasOwnProperty.call(obj, prop);
                 };

--- a/js/smartling-connector-admin.js
+++ b/js/smartling-connector-admin.js
@@ -255,7 +255,11 @@ jQuery(document).ready(function () {
 });
 
 jQuery(document).ready(function () {
-    if (window.React) {
+    /*
+     * Use class checking method for detecting Gutenberg as defined here https://github.com/WordPress/gutenberg/issues/12200
+     * This prevents conflicts with plugins that enqueue the React library when the Classic Editor is enabled.
+     */
+    if (document.body.classList.contains( 'block-editor-page' )) {
         var $ = jQuery;
         /**
          * Means that we face gutenberg and need to switch to ajax download handler.


### PR DESCRIPTION
We ran into an issue with javascript errors when submitting jobs from the page editor. I discovered that the issue was caused by having these 3 plugins:

Smartling Connector
Classic Editor
Yoast SEO (or any other plugin that enqueues the React library)

Gutenberg uses React.  Smartling Connector detects that React is loaded to determine wether or not the editor is Gutenberg vs Classic using a simple `if (window.React) { }`. Because we’re using the Classic Editor plugin, Gutenbert is disabled there should be no React.  

The problem arises with the Yoast SEO plugin. It also uses React. This makes Smartling Connector think that the editor is Gutenberg, so it tries to show alerts using the Gutenberg `core/notices`, which doesn’t exist because we’re actually using the Classic Editor.

We changed the way that Gutenberg is detected from a simple React check to using a class on the body. This method is defined here https://github.com/WordPress/gutenberg/issues/12200#issuecomment-459560313