### PR TITLE
Missing change since "removed JSON.parse() calls because of using wp_send_json() on backend" (eb683411cb9520b6f16c13a6ebc32ace643f6817) commit

### DIFF
--- a/js/smartling-connector-admin.js
+++ b/js/smartling-connector-admin.js
@@ -296,7 +296,6 @@ jQuery(document).ready(function () {
                         submissionIds: submissionIds.join(",")
                     },
                     function (data) {
-                        data = JSON.parse(data);
                         switch (data.status) {
                             case "SUCCESS":
                                 wp.data.dispatch("core/notices").createSuccessNotice("Translations downloaded.");

--- a/readme.txt
+++ b/readme.txt
@@ -61,7 +61,7 @@ Additional information on the Smartling Connector for WordPress can be found [he
 * Fixed issue with download button at post edit page.
 
 = 1.11.1 =
-* Updated 3rd party libraries.
+* Added required third-party libraries
 
 = 1.11.0 =
 * Added extension to manage shortcodes and filters to be handled by smartling-connector.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: smartling
 Tags: translation, localization, localisation, translate, multilingual, smartling, internationalization, internationalisation, automation, international
 Requires at least: 4.6
 Tested up to: 5.3
-Stable tag: 1.11.0
+Stable tag: 1.11.2
 License: GPLv2 or later
 
 Translate content in WordPress quickly and easily with Smartling’s Global Fluency Platform.
@@ -57,6 +57,12 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 1.11.2 =
+* Fixed issue with download button at post edit page.
+
+= 1.11.1 =
+* Updated 3rd party libraries.
+
 = 1.11.0 =
 * Added extension to manage shortcodes and filters to be handled by smartling-connector.
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your Wordpress site with Smartling to upload your content and download translations.
- * Version:           1.11.0
+ * Version:           1.11.2
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+


### PR DESCRIPTION
The issue is not in WP `wp_send_json` function, it works fine. the issue is that we switched from manual response sending to `wp_send_json` this one which sets `Content-type: application/json` header and `jquery.post` method is smart enough to parse the response for you. So, the issue that we tried to parse already parsed string (js object).

We have a commit `removed JSON.parse() calls because of using wp_send_json() on backend` which removes all such `JSON.parse` line but one line wasn't removed.

Also, @dimitrystd, it's strange that at wp site our plugin has `1.11.1` version (https://wordpress.org/plugins/smartling-connector/) but in repo we have only `1.11.0` tag. Is something messed up with releases?