### PR TITLE
allow dashes in post type slug for bulk submit (WP-529)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "1.13.6",
+  "version": "1.13.7",
   "description": "",
   "type": "wordpress-plugin",
   "require": {

--- a/inc/Smartling/WP/View/ContentEditJob.php
+++ b/inc/Smartling/WP/View/ContentEditJob.php
@@ -606,8 +606,8 @@ if ($post instanceof WP_Post) {
                         data.ids = [];
                         $("input.bulkaction[type=checkbox]:checked").each(function () {
                             var parts = $(this).attr("id").split("-");
-                            data.ids.push(parseInt(parts[0]));
-                            data.source.contentType = parts[1];
+                            data.ids.push(parseInt(parts.shift()));
+                            data.source.contentType = parts.join("-");
                         });
                     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 1.13.7 =
+* Fixed bulk submit page not submitting when post type slug contained dashes
+
 = 1.13.6 =
 * Fixed daily bucket job uploads handling failure due to content being added to an unsuitable translation job
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your Wordpress site with Smartling to upload your content and download translations.
- * Version:           1.13.6
+ * Version:           1.13.7
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+


### PR DESCRIPTION
I've used to know that dashes in slugs should not be used, but can't find a good source (https://docs.pluginize.com/article/135-dashes-in-post-type-taxonomy-slugs-for-url-seo)