### PR TITLE
Ingest all blocks

### DIFF
--- a/inc/Smartling/Services/ContentRelationsDiscoveryService.php
+++ b/inc/Smartling/Services/ContentRelationsDiscoveryService.php
@@ -586,9 +586,9 @@ class ContentRelationsDiscoveryService extends BaseAjaxServiceAbstract
     {
         $fields = [];
         $blocks = $this->getGutenbergBlockHelper()->parseBlocks($string);
-        foreach ($blocks as $block) {
+        foreach ($blocks as $index => $block) {
             $pointer       = 0;
-            $blockNamePart = $basename . '/' . $block['blockName'];
+            $blockNamePart = "{$basename}/{$block['blockName']}_{$index}";
             $_fields       = $block['attrs'];
 
             /**

--- a/readme.txt
+++ b/readme.txt
@@ -60,6 +60,7 @@ Additional information on the Smartling Connector for WordPress can be found [he
 == Changelog ==
 = 1.15.0 =
 * Added new UI (Smartling -> Taxonomy links) where you can link existing translated taxonomies with the source taxonomies. It helps connector to respect existing translations and use them in translated posts.
+* Fixed issue where attachments were partially uploaded if post content contained multiple ACF blocks of the same type
 
 = 1.14.2 =
 * Fixed issue where submitting related content type that was not registered in WordPress caused submission to fail

--- a/tests/IntegrationTests/tests/NewCategoryIsAttachedToPostOnDownloadTest.php
+++ b/tests/IntegrationTests/tests/NewCategoryIsAttachedToPostOnDownloadTest.php
@@ -24,8 +24,8 @@ class NewCategoryIsAttachedToPostOnDownloadTest extends SmartlingUnitTestCaseAbs
         $submission->getFileUri();
         $submission = $this->getSubmissionManager()->storeEntity($submission);
 
-        self::assertTrue(SubmissionEntity::SUBMISSION_STATUS_NEW === $submission->getStatus());
-        self::assertTrue(0 === $submission->getIsCloned());
+        self::assertSame(SubmissionEntity::SUBMISSION_STATUS_NEW, $submission->getStatus());
+        self::assertSame(0, $submission->getIsCloned());
 
         $this->uploadDownload($submission);
 
@@ -37,7 +37,7 @@ class NewCategoryIsAttachedToPostOnDownloadTest extends SmartlingUnitTestCaseAbs
             ]
         );
 
-        self::assertTrue(1 === count($submissions));
+        self::assertCount(1, $submissions);
 
         /**
          * @var SubmissionEntity $submission
@@ -54,7 +54,7 @@ class NewCategoryIsAttachedToPostOnDownloadTest extends SmartlingUnitTestCaseAbs
             ]
         );
 
-        self::assertTrue(1 === count($submissions));
+        self::assertCount(1, $submissions);
 
         /**
          * @var SubmissionEntity $submission
@@ -86,11 +86,11 @@ class NewCategoryIsAttachedToPostOnDownloadTest extends SmartlingUnitTestCaseAbs
             $siteHelper->restoreBlogId();
         }
 
-        self::assertTrue(1 === $this->count($terms));
+        self::assertCount(1, $terms);
 
         $term = ArrayHelper::first($terms);
 
-        self::assertTrue($targetCategoryId === $term->term_id);
+        self::assertSame($targetCategoryId, $term->term_id);
     }
 
 }

--- a/tests/IntegrationTests/tests/TaxonomyTest.php
+++ b/tests/IntegrationTests/tests/TaxonomyTest.php
@@ -41,8 +41,8 @@ class TaxonomyTest extends SmartlingUnitTestCaseAbstract
         $submission->getFileUri();
         $submission = $this->getSubmissionManager()->storeEntity($submission);
 
-        $this->assertTrue(SubmissionEntity::SUBMISSION_STATUS_NEW === $submission->getStatus());
-        $this->assertTrue(0 === $submission->getIsCloned());
+        self::assertSame(SubmissionEntity::SUBMISSION_STATUS_NEW, $submission->getStatus());
+        self::assertSame(0, $submission->getIsCloned());
 
         $this->uploadDownload($submission);
 
@@ -54,7 +54,7 @@ class TaxonomyTest extends SmartlingUnitTestCaseAbstract
             ]
         );
 
-        $this->assertTrue(2 === count($submissions));
+        self::assertCount(2, $submissions);
     }
 
     /**
@@ -65,8 +65,6 @@ class TaxonomyTest extends SmartlingUnitTestCaseAbstract
      */
     public function testSubmitClonedPostWithCategoryWhichHasParentCategory()
     {
-        global $wpdb;
-
         $rootCategoryId = $this->createTerm('Category A');
         $childCategoryId = $this->createTerm('Category B');
         $postId = $this->createPost();
@@ -76,8 +74,8 @@ class TaxonomyTest extends SmartlingUnitTestCaseAbstract
         $translationHelper = $this->getTranslationHelper();
         $submission = $translationHelper->prepareSubmission('post', 1, $postId, 2, true);
 
-        $this->assertTrue(SubmissionEntity::SUBMISSION_STATUS_NEW === $submission->getStatus());
-        $this->assertTrue(1 === $submission->getIsCloned());
+        self::assertSame(SubmissionEntity::SUBMISSION_STATUS_NEW, $submission->getStatus());
+        self::assertSame(1, $submission->getIsCloned());
 
         $this->uploadDownload($submission);
 
@@ -96,6 +94,6 @@ class TaxonomyTest extends SmartlingUnitTestCaseAbstract
             ]
         );
 
-        $this->assertTrue(2 === count($submissions));
+        self::assertCount(2, $submissions);
     }
 }


### PR DESCRIPTION
Previously, blocks got duplicated if multiple were used on same page. By adding the block index, we're able to process all blocks.