### PR TITLE
fix relations after menu translation (WP-589)

### DIFF
--- a/inc/Smartling/Bootstrap.php
+++ b/inc/Smartling/Bootstrap.php
@@ -23,7 +23,6 @@ use Smartling\Helpers\SiteHelper;
 use Smartling\Helpers\SmartlingUserCapabilities;
 use Smartling\MonologWrapper\MonologWrapper;
 use Smartling\Services\GlobalSettingsManager;
-use Smartling\Settings\SettingsManager;
 use Smartling\WP\WPInstallableInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 

--- a/inc/Smartling/WP/Controller/PostBasedWidgetControllerStd.php
+++ b/inc/Smartling/WP/Controller/PostBasedWidgetControllerStd.php
@@ -153,7 +153,6 @@ class PostBasedWidgetControllerStd extends WPAbstract implements WPHookInterface
 
     public function ajaxUploadHandler()
     {
-        $this->getLogger()->debug("Usage: class='" . __CLASS__ . "', function='" . __FUNCTION__ . "'");
         $result = [];
 
         $data = &$_POST;

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,7 @@ Additional information on the Smartling Connector for WordPress can be found [he
 == Changelog ==
 = 2.3.0 =
 * Added ability to use all registered post types for references in Gutenberg blocks
+* Fixed menu translation when menu items consisted of post types or taxonomies
 
 = 2.2.1 =
 * Fixed critical wordpress error on new profile creation


### PR DESCRIPTION
This also seems to resolve non-translated menu items not being visible after translation due to broken metadata