### PR TITLE
change cloning workflow (WP-647)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c263daa0aff1fccfd373a50171631188",
+    "content-hash": "d474ee06c3dce791a07c0ee386ccb783",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1808,16 +1808,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.20",
+            "version": "8.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9deefba183198398a09b927a6ac6bc1feb0b7b70"
+                "reference": "50a58a60b85947b0bee4c8ecfe0f4bbdcf20e984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9deefba183198398a09b927a6ac6bc1feb0b7b70",
-                "reference": "9deefba183198398a09b927a6ac6bc1feb0b7b70",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/50a58a60b85947b0bee4c8ecfe0f4bbdcf20e984",
+                "reference": "50a58a60b85947b0bee4c8ecfe0f4bbdcf20e984",
                 "shasum": ""
             },
             "require": {
@@ -1889,7 +1889,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.21"
             },
             "funding": [
                 {
@@ -1901,7 +1901,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-08-31T06:44:38+00:00"
+            "time": "2021-09-25T07:37:20+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/inc/Smartling/Base/ExportedAPI.php
+++ b/inc/Smartling/Base/ExportedAPI.php
@@ -44,6 +44,11 @@ interface ExportedAPI
     const EVENT_SMARTLING_AFTER_DESERIALIZE_CONTENT = 'smartling_after_deserialize_content';
 
     /**
+     * Action that prepares submission for upload and creates target placeholders
+     */
+    public const ACTION_SMARTLING_PREPARE_SUBMISSION_UPLOAD = 'smartling_prepare_submission_upload';
+
+    /**
      * Action that sends given SubmissionEntity to smartling for translation
      */
     const ACTION_SMARTLING_SEND_FILE_FOR_TRANSLATION = 'smartling_send_for_translation';

--- a/inc/Smartling/Base/SmartlingCore.php
+++ b/inc/Smartling/Base/SmartlingCore.php
@@ -32,15 +32,20 @@ class SmartlingCore extends SmartlingCoreAbstract
     {
         parent::__construct();
 
+        add_action(ExportedAPI::ACTION_SMARTLING_CLONE_CONTENT, [$this, 'cloneContent']);
+        add_action(ExportedAPI::ACTION_SMARTLING_PREPARE_SUBMISSION_UPLOAD, [$this, 'prepareUpload']);
         add_action(ExportedAPI::ACTION_SMARTLING_SEND_FILE_FOR_TRANSLATION, [$this, 'sendForTranslationBySubmission']);
         add_action(ExportedAPI::ACTION_SMARTLING_DOWNLOAD_TRANSLATION, [$this, 'downloadTranslationBySubmission',]);
         add_action(ExportedAPI::ACTION_SMARTLING_REGENERATE_THUMBNAILS, [$this, 'regenerateTargetThumbnailsBySubmission']);
         add_filter(ExportedAPI::FILTER_SMARTLING_PREPARE_TARGET_CONTENT, [$this, 'prepareTargetContent']);
         add_action(ExportedAPI::ACTION_SMARTLING_SYNC_MEDIA_ATTACHMENT, [$this, 'syncAttachment']);
-        /** @noinspection UnusedConstructorDependenciesInspection used in \Smartling\Base\SmartlingCoreDownloadTrait::downloadTranslationBySubmission */
         $this->postContentHelper = $postContentHelper;
-        /** @noinspection UnusedConstructorDependenciesInspection used in \Smartling\Base\SmartlingCoreDownloadTrait::downloadTranslationBySubmission */
         $this->xmlHelper = $xmlHelper;
+    }
+
+    public function cloneContent(SubmissionEntity $submission): void
+    {
+        $this->applyXML($submission, $this->getXMLFiltered($submission), $this->xmlHelper, $this->postContentHelper);
     }
 
     /**

--- a/inc/Smartling/Base/SmartlingCoreUploadTrait.php
+++ b/inc/Smartling/Base/SmartlingCoreUploadTrait.php
@@ -63,8 +63,52 @@ trait SmartlingCoreUploadTrait
         return new WordpressFunctionProxyHelper();
     }
 
+    public function prepareUpload(SubmissionEntity $submission): SubmissionEntity
+    {
+        return $this->renewContentHash(
+            $this->createTargetContent(
+                $this->setFileUriIfNullId($submission)
+            )
+        );
+    }
+
+    private function setFileUriIfNullId(SubmissionEntity $submission): SubmissionEntity
+    {
+        if (null === $submission->getId()) {
+            // generate URI
+            $submission->getFileUri();
+            $submission = $this->getSubmissionManager()->storeEntity($submission);
+        }
+
+        return $submission;
+    }
+
+    private function createTargetContent(SubmissionEntity $submission): SubmissionEntity
+    {
+        $submission = $this->getFunctionProxyHelper()->apply_filters(ExportedAPI::FILTER_SMARTLING_PREPARE_TARGET_CONTENT, $submission);
+
+        if (SubmissionEntity::SUBMISSION_STATUS_FAILED === $submission->getStatus()) {
+            $msg = vsprintf(
+                'Failed creating target placeholder for submission id=\'%s\', source_blog_id=\'%s\', source_id=\'%s\', target_blog_id=\'%s\', target_id=\'%s\' with message: \'%s\'',
+                [
+                    $submission->getId(),
+                    $submission->getSourceBlogId(),
+                    $submission->getSourceId(),
+                    $submission->getTargetBlogId(),
+                    $submission->getTargetId(),
+                    $submission->getLastError(),
+                ]
+            );
+            $this->getLogger()->error($msg);
+            throw new SmartlingTargetPlaceholderCreationFailedException($msg);
+        }
+
+        return $submission;
+    }
+
     /**
-     * Processes content by submission and returns only XML string for translation
+     * Prepare submission for upload and return XML string for translation
+     * @see prepareUpload
      */
     public function getXMLFiltered(SubmissionEntity $submission): string
     {
@@ -81,36 +125,7 @@ trait SmartlingCoreUploadTrait
         );
 
         try {
-            if (null === $submission->getId()) {
-                // generate URI
-                $submission->getFileUri();
-                $submission = $this->getSubmissionManager()->storeEntity($submission);
-            }
-
-            $submission = $this
-                ->getFunctionProxyHelper()
-                ->apply_filters(ExportedAPI::FILTER_SMARTLING_PREPARE_TARGET_CONTENT, $submission);
-
-            /**
-             * Creating of target placeholder has failed
-             */
-            if (SubmissionEntity::SUBMISSION_STATUS_FAILED === $submission->getStatus()) {
-                $msg = vsprintf(
-                    'Failed creating target placeholder for submission id=\'%s\', source_blog_id=\'%s\', source_id=\'%s\', target_blog_id=\'%s\', target_id=\'%s\' with message: \'%s\'',
-                    [
-                        $submission->getId(),
-                        $submission->getSourceBlogId(),
-                        $submission->getSourceId(),
-                        $submission->getTargetBlogId(),
-                        $submission->getTargetId(),
-                        $submission->getLastError(),
-                    ]
-                );
-                $this->getLogger()->error($msg);
-                throw new SmartlingTargetPlaceholderCreationFailedException($msg);
-            }
-
-            $submission = $this->renewContentHash($submission);
+            $submission = $this->prepareUpload($submission);
 
             $source = $this->readSourceContentWithMetadataAsArray($submission);
 

--- a/inc/Smartling/Jobs/UploadJob.php
+++ b/inc/Smartling/Jobs/UploadJob.php
@@ -22,6 +22,8 @@ class UploadJob extends JobAbstract
 
         $this->processUploadQueue();
 
+        $this->processCloning();
+
         $this->processDailyBucketJob();
 
         $this->getLogger()->info('Finished UploadJob.');
@@ -56,6 +58,18 @@ class UploadJob extends JobAbstract
             do_action(ExportedAPI::ACTION_SMARTLING_SEND_FILE_FOR_TRANSLATION, $entity);
             $this->placeLockFlag(true);
         } while (0 < count($entities));
+    }
+
+    private function processCloning(): void
+    {
+        $submissions = $this->submissionManager->findSubmissionsForCloning();
+        foreach ($submissions as $submission) {
+            do_action(ExportedAPI::ACTION_SMARTLING_PREPARE_SUBMISSION_UPLOAD, $submission);
+        }
+        // needs to be in a separate loop to have all relations when cloning
+        foreach ($submissions as $submission) {
+            do_action(ExportedAPI::ACTION_SMARTLING_CLONE_CONTENT, $submission);
+        }
     }
 
     private function processDailyBucketJob(): void

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 5.7
 Requires PHP: 7.4
-Stable tag: 2.7.0
+Stable tag: 2.7.1
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 2.7.1 =
+* Fixed relations not changed in target blog when cloning
+
 = 2.7.0 =
 * Switched from database to external service locking for cron jobs. It avoids the issue when hosting doesn't allow SQL `SELECT ... FOR UPDATE`
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your Wordpress site with Smartling to upload your content and download translations.
- * Version:           2.7.0
+ * Version:           2.7.1
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/Smartling/Submissions/SubmissionManagerTest.php
+++ b/tests/Smartling/Submissions/SubmissionManagerTest.php
@@ -111,7 +111,7 @@ class SubmissionManagerTest extends TestCase
         $db = $this->db;
         $x = $this->subject;
         $x->method('getDbal')->willReturn($db);
-        $x->expects($this->once())->method('fetchData')->with("SELECT `id`, `source_title`, `source_blog_id`, `source_content_hash`, `content_type`, `source_id`, `file_uri`, `target_locale`, `target_blog_id`, `target_id`, `submitter`, `submission_date`, `applied_date`, `approved_string_count`, `completed_string_count`, `excluded_string_count`, `total_string_count`, `word_count`, `status`, `is_locked`, `is_cloned`, `last_modified`, `outdated`, `last_error`, `batch_uid`, `locked_fields` FROM `wp_smartling_submissions` WHERE ( ( `status` = 'New' AND `is_locked` = '0' ) AND ( `is_cloned` = '1' OR `batch_uid` <> '' ) ) LIMIT 0,1")->willReturn([]);
+        $x->expects($this->once())->method('fetchData')->with("SELECT `id`, `source_title`, `source_blog_id`, `source_content_hash`, `content_type`, `source_id`, `file_uri`, `target_locale`, `target_blog_id`, `target_id`, `submitter`, `submission_date`, `applied_date`, `approved_string_count`, `completed_string_count`, `excluded_string_count`, `total_string_count`, `word_count`, `status`, `is_locked`, `is_cloned`, `last_modified`, `outdated`, `last_error`, `batch_uid`, `locked_fields` FROM `wp_smartling_submissions` WHERE ( `status` = 'New' AND `is_locked` = '0' AND `batch_uid` <> '' ) LIMIT 0,1")->willReturn([]);
 
         $x->findSubmissionsForUploadJob();
     }


### PR DESCRIPTION
When cloning submissions, they previously applied XML immediatelyat upload job run. This could cause issues when a posts relation was not yet processed, resulting in copying the relation ids instead of altering them as needed. After this PR, every cloned submission first creates target content, then XML is applied with all existing relations having proper target ids.