### PR TITLE
add json serializer with fallback (WP-663)

### DIFF
--- a/inc/Smartling/Base/SmartlingCoreUploadTrait.php
+++ b/inc/Smartling/Base/SmartlingCoreUploadTrait.php
@@ -153,7 +153,7 @@ trait SmartlingCoreUploadTrait
             }
 
             $this->prepareFieldProcessorValues($submission);
-            return XmlHelper::xmlEncode($filteredValues, $submission, $source);
+            return $this->xmlHelper->xmlEncode($filteredValues, $submission, $source);
         } catch (EntityNotFoundException $e) {
             $this->getLogger()->error($e->getMessage());
             $this->getSubmissionManager()->setErrorMessage($submission, 'Submission references non existent content.');
@@ -858,6 +858,6 @@ trait SmartlingCoreUploadTrait
             return '';
         }
 
-        return XmlHelper::xmlEncode($filteredValues, $submission, $params->getPreparedFields());
+        return $this->xmlHelper->xmlEncode($filteredValues, $submission, $params->getPreparedFields());
     }
 }

--- a/inc/Smartling/Helpers/GutenbergBlockHelper.php
+++ b/inc/Smartling/Helpers/GutenbergBlockHelper.php
@@ -10,6 +10,7 @@ use Smartling\Exception\SmartlingGutenbergNotFoundException;
 use Smartling\Exception\SmartlingGutenbergParserNotFoundException;
 use Smartling\Exception\SmartlingNotSupportedContentException;
 use Smartling\Helpers\EventParameters\TranslationStringFilterParameters;
+use Smartling\Helpers\Serializers\SerializerInterface;
 use Smartling\Models\GutenbergBlock;
 use Smartling\Replacers\ReplacerFactory;
 use Smartling\Submissions\SubmissionEntity;
@@ -24,12 +25,14 @@ class GutenbergBlockHelper extends SubstringProcessorHelperAbstract
 
     private MediaAttachmentRulesManager $rulesManager;
     private ReplacerFactory $replacerFactory;
+    private SerializerInterface $serializer;
 
-    public function __construct(MediaAttachmentRulesManager $rulesManager, ReplacerFactory $replacerFactory)
+    public function __construct(MediaAttachmentRulesManager $rulesManager, ReplacerFactory $replacerFactory, SerializerInterface $serializer)
     {
         parent::__construct();
         $this->replacerFactory = $replacerFactory;
         $this->rulesManager = $rulesManager;
+        $this->serializer = $serializer;
     }
 
     public function registerFilters(array $definitions): array
@@ -103,12 +106,12 @@ class GutenbergBlockHelper extends SubstringProcessorHelperAbstract
 
     private function packData(array $data): string
     {
-        return base64_encode(serialize($data));
+        return $this->serializer->serialize($data);
     }
 
     private function unpackData(string $data): array
     {
-        return unserialize(base64_decode($data));
+        return $this->serializer->unserialize($data);
     }
 
     private function placeBlock(GutenbergBlock $block): \DOMElement

--- a/inc/Smartling/Helpers/Serializers/SerializerJsonWithFallback.php
+++ b/inc/Smartling/Helpers/Serializers/SerializerJsonWithFallback.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Smartling\Helpers\Serializers;
+
+class SerializerJsonWithFallback implements SerializerInterface {
+    public function getType(): string
+    {
+        return 'json';
+    }
+
+    public function serialize($data): string
+    {
+        return base64_encode(json_encode($data, JSON_FORCE_OBJECT | JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+
+    public function unserialize($string): array
+    {
+        try {
+            return json_decode(base64_decode($string), true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            return unserialize(base64_decode($string));
+        }
+    }
+}

--- a/inc/Smartling/Helpers/Serializers/SerializerJsonWithFallback.php
+++ b/inc/Smartling/Helpers/Serializers/SerializerJsonWithFallback.php
@@ -18,6 +18,7 @@ class SerializerJsonWithFallback implements SerializerInterface {
         try {
             return json_decode(base64_decode($string), true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
+            // not JSON, try with php built in unserialize()
             return unserialize(base64_decode($string));
         }
     }

--- a/inc/Smartling/Helpers/Serializers/SerializerJsonWithFallback.php
+++ b/inc/Smartling/Helpers/Serializers/SerializerJsonWithFallback.php
@@ -19,7 +19,7 @@ class SerializerJsonWithFallback implements SerializerInterface {
             return json_decode(base64_decode($string), true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
             // not JSON, try with php built in unserialize()
-            return unserialize(base64_decode($string));
+            return unserialize(base64_decode($string), ['allowed_classes' => false]);
         }
     }
 }

--- a/inc/config/serializer.yml
+++ b/inc/config/serializer.yml
@@ -13,6 +13,9 @@ services:
       - [ "setDelimiter", [ "%coma%" ] ]
       - [ "setType", [ "coma-separated" ] ]
 
+  serializer.json:
+    class: Smartling\Helpers\Serializers\SerializerJsonWithFallback
+
   manager.serializer:
     class: Smartling\Helpers\Serializers\SerializationManager
     calls:

--- a/inc/config/services.yml
+++ b/inc/config/services.yml
@@ -45,6 +45,8 @@ services:
 
   helper.xml:
     class: Smartling\Helpers\XmlHelper
+    arguments:
+      - "@serializer.json"
 
   wrapper.sdk.api.smartling:
     class: Smartling\ApiWrapper
@@ -239,6 +241,7 @@ services:
     arguments:
       - "@media.attachment.rules.manager"
       - "@factory.replacer"
+      - "@serializer.json"
     calls:
       - [ "setFieldsFilter", [ "@fields-filter.helper" ]]
 

--- a/tests/Smartling/Base/SmartlingCoreTest.php
+++ b/tests/Smartling/Base/SmartlingCoreTest.php
@@ -9,6 +9,7 @@ use Smartling\Exception\SmartlingDirectRunRuntimeException;
 use Smartling\Exception\SmartlingTargetPlaceholderCreationFailedException;
 use Smartling\Helpers\GutenbergBlockHelper;
 use Smartling\Helpers\PostContentHelper;
+use Smartling\Helpers\Serializers\SerializerJsonWithFallback;
 use Smartling\Helpers\XmlHelper;
 use Smartling\Jobs\JobEntityWithBatchUid;
 use Smartling\Replacers\ReplacerFactory;
@@ -47,10 +48,11 @@ class SmartlingCoreTest extends TestCase
             new PostContentHelper(
                 new GutenbergBlockHelper(
                     $this->createMock(MediaAttachmentRulesManager::class),
-                    $this->createMock(ReplacerFactory::class)
+                    $this->createMock(ReplacerFactory::class),
+                    new SerializerJsonWithFallback(),
                 )
             ),
-            new XmlHelper(),
+            new XmlHelper(new SerializerJsonWithFallback()),
         );
     }
 

--- a/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
+++ b/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
@@ -11,6 +11,7 @@ use Smartling\Helpers\DecodedXml;
 use Smartling\Helpers\FieldsFilterHelper;
 use Smartling\Helpers\GutenbergBlockHelper;
 use Smartling\Helpers\PostContentHelper;
+use Smartling\Helpers\Serializers\SerializerJsonWithFallback;
 use Smartling\Helpers\XmlHelper;
 use Smartling\Replacers\ReplacerFactory;
 use Smartling\Settings\ConfigurationProfileEntity;
@@ -566,6 +567,7 @@ HTML;
         $postContentHelper = new PostContentHelper(new GutenbergBlockHelper(
             $this->createMock(MediaAttachmentRulesManager::class),
             $this->createMock(ReplacerFactory::class),
+            new SerializerJsonWithFallback(),
         ));
         self::assertEquals([], $smartlingCoreUpload->applyXML($submission, ' ', $xmlHelper, $postContentHelper));
     }

--- a/tests/Smartling/Helpers/GutenbergBlockHelperTest.php
+++ b/tests/Smartling/Helpers/GutenbergBlockHelperTest.php
@@ -46,6 +46,7 @@ namespace Smartling\Tests\Smartling\Helpers {
     use Smartling\Helpers\EventParameters\TranslationStringFilterParameters;
     use Smartling\Helpers\FieldsFilterHelper;
     use Smartling\Helpers\GutenbergBlockHelper;
+    use Smartling\Helpers\Serializers\SerializerJsonWithFallback;
     use Smartling\Models\GutenbergBlock;
     use Smartling\Replacers\ReplacerFactory;
     use Smartling\Submissions\SubmissionEntity;
@@ -67,6 +68,7 @@ namespace Smartling\Tests\Smartling\Helpers {
             ->setConstructorArgs([
                 $this->createMock(MediaAttachmentRulesManager::class),
                 $this->createMock(ReplacerFactory::class),
+                new SerializerJsonWithFallback(),
             ])
             ->onlyMethods($methods)
             ->getMock();
@@ -76,7 +78,11 @@ namespace Smartling\Tests\Smartling\Helpers {
 
     protected function setUp(): void
     {
-        $this->helper = new GutenbergBlockHelper($this->createMock(MediaAttachmentRulesManager::class), $this->createMock(ReplacerFactory::class));
+        $this->helper = new GutenbergBlockHelper(
+            $this->createMock(MediaAttachmentRulesManager::class),
+            $this->createMock(ReplacerFactory::class),
+            new SerializerJsonWithFallback(),
+        );
     }
 
     public function testAddPostContentBlocksWithBlocks()
@@ -188,22 +194,6 @@ HTML
         ];
     }
 
-    public function testPackData()
-    {
-        $sample = ['foo' => 'bar'];
-        $expected = base64_encode(serialize($sample));
-        $result = $this->invokeMethod($this->helper, 'packData', [$sample]);
-        self::assertEquals($expected, $result);
-    }
-
-    public function testUnpackData()
-    {
-        $sample = ['foo' => 'bar'];
-        $source = base64_encode(serialize($sample));
-        $result = $this->invokeMethod($this->helper, 'unpackData', [$source]);
-        self::assertEquals($sample, $result);
-    }
-
     public function testPackUnpack()
     {
         $sample = ['foo' => 'bar'];
@@ -260,7 +250,7 @@ HTML
                         'chunk c',
                     ],
                 ],
-                '<gutenbergBlock blockName="test" originalAttributes="YToxOntzOjM6ImZvbyI7czozOiJiYXIiO30="><![CDATA[]]><contentChunk><![CDATA[chunk a]]></contentChunk><contentChunk><![CDATA[chunk b]]></contentChunk><contentChunk><![CDATA[chunk c]]></contentChunk><blockAttribute name="foo"><![CDATA[bar]]></blockAttribute></gutenbergBlock>',
+                '<gutenbergBlock blockName="test" originalAttributes="eyJmb28iOiJiYXIifQ=="><![CDATA[]]><contentChunk><![CDATA[chunk a]]></contentChunk><contentChunk><![CDATA[chunk b]]></contentChunk><contentChunk><![CDATA[chunk c]]></contentChunk><blockAttribute name="foo"><![CDATA[bar]]></blockAttribute></gutenbergBlock>',
             ],
             'nested block' => [
                 [
@@ -287,7 +277,7 @@ HTML
                         'chunk c',
                     ],
                 ],
-                '<gutenbergBlock blockName="test" originalAttributes="YToxOntzOjM6ImZvbyI7czozOiJiYXIiO30="><![CDATA[]]><contentChunk><![CDATA[chunk a]]></contentChunk><gutenbergBlock blockName="test1" originalAttributes="YToxOntzOjM6ImJhciI7czozOiJmb28iO30="><![CDATA[]]><contentChunk><![CDATA[chunk d]]></contentChunk><contentChunk><![CDATA[chunk e]]></contentChunk><contentChunk><![CDATA[chunk f]]></contentChunk><blockAttribute name="bar"><![CDATA[foo]]></blockAttribute></gutenbergBlock><contentChunk><![CDATA[chunk c]]></contentChunk><blockAttribute name="foo"><![CDATA[bar]]></blockAttribute></gutenbergBlock>',
+                '<gutenbergBlock blockName="test" originalAttributes="eyJmb28iOiJiYXIifQ=="><![CDATA[]]><contentChunk><![CDATA[chunk a]]></contentChunk><gutenbergBlock blockName="test1" originalAttributes="eyJiYXIiOiJmb28ifQ=="><![CDATA[]]><contentChunk><![CDATA[chunk d]]></contentChunk><contentChunk><![CDATA[chunk e]]></contentChunk><contentChunk><![CDATA[chunk f]]></contentChunk><blockAttribute name="bar"><![CDATA[foo]]></blockAttribute></gutenbergBlock><contentChunk><![CDATA[chunk c]]></contentChunk><blockAttribute name="foo"><![CDATA[bar]]></blockAttribute></gutenbergBlock>',
             ],
         ];
     }
@@ -617,10 +607,10 @@ some par 2
                         ],
                     ],
                 ],
-                '<string name="entity/post_content"><gutenbergBlock blockName="core/paragraph" originalAttributes="YTowOnt9"><![CDATA[]]><contentChunk><![CDATA[
+                '<string name="entity/post_content"><gutenbergBlock blockName="core/paragraph" originalAttributes="e30="><![CDATA[]]><contentChunk><![CDATA[
 some par 1
 
-]]></contentChunk></gutenbergBlock><gutenbergBlock blockName="" originalAttributes="YTowOnt9"><![CDATA[]]><contentChunk><![CDATA[ ]]></contentChunk></gutenbergBlock><gutenbergBlock blockName="core/paragraph" originalAttributes="YTowOnt9"><![CDATA[]]><contentChunk><![CDATA[
+]]></contentChunk></gutenbergBlock><gutenbergBlock blockName="" originalAttributes="e30="><![CDATA[]]><contentChunk><![CDATA[ ]]></contentChunk></gutenbergBlock><gutenbergBlock blockName="core/paragraph" originalAttributes="e30="><![CDATA[]]><contentChunk><![CDATA[
 some par 2
 
 ]]></contentChunk></gutenbergBlock><![CDATA[]]></string>',
@@ -711,7 +701,7 @@ some par 2
         if ($replacerFactory === null) {
             $replacerFactory = $this->createMock(ReplacerFactory::class);
         }
-        return new GutenbergBlockHelper($rulesManager, $replacerFactory);
+        return new GutenbergBlockHelper($rulesManager, $replacerFactory, new SerializerJsonWithFallback());
     }
 }
 }


### PR DESCRIPTION
Switching to json serializer immediately would break existing translation jobs. For now, we need to add a fallback unserialization procedure for these.