### PR TITLE
fix media library items duplication when cloning (WP-675)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "",
   "type": "wordpress-plugin",
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f41abee12bcd38141ee29ca6291c3ce",
+    "content-hash": "c04d1aaf94bb2d255c350a28f0222383",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1240,9 +1240,6 @@
             },
             "require": {
                 "php": "^7.1 || ^8.0"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
@@ -2864,5 +2861,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/inc/Smartling/Jobs/UploadJob.php
+++ b/inc/Smartling/Jobs/UploadJob.php
@@ -62,12 +62,8 @@ class UploadJob extends JobAbstract
 
     private function processCloning(): void
     {
-        $submissions = $this->submissionManager->findSubmissionsForCloning();
-        foreach ($submissions as $submission) {
+        while (($submission = $this->submissionManager->findSubmissionForCloning()) !== null) {
             do_action(ExportedAPI::ACTION_SMARTLING_PREPARE_SUBMISSION_UPLOAD, $submission);
-        }
-        // needs to be in a separate loop to have all relations when cloning
-        foreach ($submissions as $submission) {
             do_action(ExportedAPI::ACTION_SMARTLING_CLONE_CONTENT, $submission);
         }
     }

--- a/inc/Smartling/Submissions/SubmissionManager.php
+++ b/inc/Smartling/Submissions/SubmissionManager.php
@@ -310,17 +310,21 @@ class SubmissionManager extends EntityManagerAbstract
         return $this->fetchData($query);
     }
 
-    public function findSubmissionsForCloning(): array
+    public function findSubmissionForCloning(): ?SubmissionEntity
     {
         $block = new ConditionBlock(ConditionBuilder::CONDITION_BLOCK_LEVEL_OPERATOR_AND);
         $block->addCondition(Condition::getCondition(ConditionBuilder::CONDITION_SIGN_EQ, SubmissionEntity::FIELD_STATUS, [SubmissionEntity::SUBMISSION_STATUS_NEW]));
         $block->addCondition(Condition::getCondition(ConditionBuilder::CONDITION_SIGN_EQ, SubmissionEntity::FIELD_IS_CLONED, [1]));
 
-        return $this->fetchData(QueryBuilder::buildSelectQuery(
+        $data = $this->fetchData(QueryBuilder::buildSelectQuery(
             $this->getDbal()->completeTableName(SubmissionEntity::getTableName()),
             array_keys(SubmissionEntity::getFieldDefinitions()),
-            $block
+            $block,
+            null,
+            ['limit' => 1, 'page' => 1],
         ));
+
+        return ArrayHelper::first($data) ?: null;
     }
     /**
      * @param int[] $ids

--- a/readme.txt
+++ b/readme.txt
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 2.11.1 =
+* Fixed media library attachments duplication when cloning
+
 = 2.11.0 =
 * Added test run. Test run submits posts and pages to a new blog for "pseudo" translation. This should help quickly check compatibility between your content and the plugin.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 5.7
 Requires PHP: 7.4
-Stable tag: 2.11.0
+Stable tag: 2.11.1
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           2.11.0
+ * Version:           2.11.1
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/IntegrationTests/SmartlingUnitTestCaseAbstract.php
+++ b/tests/IntegrationTests/SmartlingUnitTestCaseAbstract.php
@@ -17,6 +17,7 @@ use Smartling\Jobs\SubmissionJobEntity;
 use Smartling\Jobs\UploadJob;
 use Smartling\MonologWrapper\MonologWrapper;
 use Smartling\Queue\Queue;
+use Smartling\Services\ContentRelationsDiscoveryService;
 use Smartling\Services\GlobalSettingsManager;
 use Smartling\Settings\ConfigurationProfileEntity;
 use Smartling\Settings\Locale;
@@ -131,6 +132,27 @@ abstract class SmartlingUnitTestCaseAbstract extends WP_UnitTestCase
     private static function getWPInstallDirEnv(): string
     {
         return getenv('WP_INSTALL_DIR');
+    }
+
+    public function getContentRelationsDiscoveryService(): ContentRelationsDiscoveryService
+    {
+        return $this->get('service.relations-discovery');
+    }
+
+    public function withBlockRules(MediaAttachmentRulesManager $manager, array $rules, callable $function)
+    {
+        try {
+            foreach ($rules as $offset => $value) {
+                $manager->offsetSet($offset, $value);
+            }
+            $manager->saveData();
+            return $function();
+        } finally {
+            foreach (array_keys($rules) as $offset) {
+                $manager->offsetUnset($offset);
+            }
+            $manager->saveData();
+        }
     }
 
     protected function uploadDownload(SubmissionEntity $submission): ?SubmissionEntity

--- a/tests/IntegrationTests/tests/CloneTest.php
+++ b/tests/IntegrationTests/tests/CloneTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace IntegrationTests\tests;
+
+use Smartling\Tests\IntegrationTests\SmartlingUnitTestCaseAbstract;
+
+class CloneTest extends SmartlingUnitTestCaseAbstract
+{
+    public function testNoMediaDuplicationOnCloning(): void
+    {
+        $targetBlogId = 2;
+        switch_to_blog($targetBlogId);
+        $attachmentCount = count($this->getAttachments());
+        restore_current_blog();
+
+        $childPostId = $this->createPost('post', 'embedded post', 'embedded content');
+        $imageId = $this->createAttachment();
+        set_post_thumbnail($childPostId, $imageId);
+        $rootPostId = $this->createPost('post', 'root post', "<!-- wp:test/post {\"id\":$childPostId} /-->");
+
+        $this->withBlockRules($this->getRulesManager(), [
+            'test' => [
+                'block' => 'test/post',
+                'path' => 'id',
+                'replacerId' => 'related|post',
+            ],
+        ], function () use ($childPostId, $imageId, $rootPostId, $targetBlogId) {
+            $relationsDiscoveryService = $this->getContentRelationsDiscoveryService();
+            $references = $relationsDiscoveryService->getRelations('post', $rootPostId, [$targetBlogId]);
+            $this->assertCount(1, $references->getMissingReferences()[$targetBlogId]['post']);
+            $this->assertEquals($childPostId, $references->getMissingReferences()[$targetBlogId]['post'][0]);
+            $relationsDiscoveryService->clone([
+                'source' => [
+                    'contentType' => 'post',
+                    'id' => [$rootPostId],
+                ],
+                'targetBlogIds' => $targetBlogId,
+                'relations' => [
+                    $targetBlogId => [
+                        'post' => [$childPostId],
+                        'attachment' => [$imageId],
+                    ],
+                ],
+            ]);
+            $this->executeUpload();
+        });
+
+        switch_to_blog($targetBlogId);
+        $this->assertCount($attachmentCount + 1, $this->getAttachments(), 'Expected exactly one more attachment in target blog after cloning');
+        restore_current_blog();
+    }
+
+    private function getAttachments(): array
+    {
+        self::flush_cache();
+        return get_posts(['post_type' => 'attachment']);
+    }
+}


### PR DESCRIPTION
What previously happened was an attachment being created two times: first because it was detected by related media processor, second because it was queued for cloning. Now we get submissions for cloning not in bulk, but one by one, thus on second run we already know it was cloned to the target blog