### PR TITLE
Exclude cloned submissions from status checks (WP-684)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "2.11.1",
+  "version": "2.11.5",
   "description": "",
   "type": "wordpress-plugin",
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c04d1aaf94bb2d255c350a28f0222383",
+    "content-hash": "c54fa427cc079669d8819b7b321b52a3",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/inc/Smartling/Base/SmartlingCoreUploadTrait.php
+++ b/inc/Smartling/Base/SmartlingCoreUploadTrait.php
@@ -511,6 +511,7 @@ trait SmartlingCoreUploadTrait
                     foreach ($submissions as $_submission) {
                         $_submission->setBatchUid('');
                         $_submission->setStatus(SubmissionEntity::SUBMISSION_STATUS_FAILED);
+                        $this->getLogger()->debug("Failing submission {$_submission->getId()}: failed to send file. Additional information should be in prior logs");
                     }
                 }
                 $this->getSubmissionManager()->storeSubmissions($submissions);

--- a/inc/Smartling/Jobs/LastModifiedCheckJob.php
+++ b/inc/Smartling/Jobs/LastModifiedCheckJob.php
@@ -103,9 +103,7 @@ class LastModifiedCheckJob extends JobAbstract
                 $lastModified = $this->api->lastModified($submission);
             } catch (SmartlingNetworkException $e) {
                 if ($this->api->isUnrecoverable($e)) {
-                    $submission->setStatus(SubmissionEntity::SUBMISSION_STATUS_FAILED);
-                    $this->submissionManager->storeEntity($submission);
-                    $this->getLogger()->warning("Marking submission {$submission->getId()} failed because of an unrecoverable error in ApiWrapper::lastModified response");
+                    $this->submissionManager->setErrorMessage($submission, $e->getMessage());
                 }
                 throw $e;
             }

--- a/inc/Smartling/Submissions/SubmissionManager.php
+++ b/inc/Smartling/Submissions/SubmissionManager.php
@@ -631,6 +631,7 @@ class SubmissionManager extends EntityManagerAbstract
                 ]
             )
         );
+        $block->addCondition(Condition::getCondition(ConditionBuilder::CONDITION_SIGN_NOT_EQ, SubmissionEntity::FIELD_IS_CLONED, [1]));
         $query = QueryBuilder::buildSelectQuery(
             $this->getDbal()->completeTableName(SubmissionEntity::getTableName()),
             [

--- a/readme.txt
+++ b/readme.txt
@@ -63,7 +63,7 @@ Additional information on the Smartling Connector for WordPress can be found [he
 
 == Changelog ==
 = 2.11.5 =
-* Fixed cloned submissions failing from completed status after time passes
+* Cloned submissions are excluded from status check background job. This change fixes cloned submissions changing status from completed to failed after time passes
 
 = 2.11.4 =
 * Fixed upload widget not uploading content

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 5.9
 Requires PHP: 7.4
-Stable tag: 2.11.3
+Stable tag: 2.11.5
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 2.11.5 =
+* Fixed cloned submissions failing from completed status after time passes
+
 = 2.11.4 =
 * Fixed upload widget not uploading content
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           2.11.4
+ * Version:           2.11.5
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/Jobs/LastModifiedCheckJobTest.php
+++ b/tests/Jobs/LastModifiedCheckJobTest.php
@@ -425,7 +425,7 @@ class LastModifiedCheckJobTest extends TestCase
 
         $this->submissionManager
             ->expects(self::exactly($storeEntityCount))
-            ->method('storeEntity');
+            ->method('setErrorMessage');
 
         $worker->run();
     }

--- a/tests/Smartling/Submissions/SubmissionManagerTest.php
+++ b/tests/Smartling/Submissions/SubmissionManagerTest.php
@@ -190,7 +190,7 @@ class SubmissionManagerTest extends TestCase
     public function testGetGroupedIdsByFileUri()
     {
         $db = $this->db;
-        $db->expects($this->once())->method('fetch')->with("SELECT `file_uri` AS `fileUri`, GROUP_CONCAT(`id`) AS `ids` FROM `wp_smartling_submissions` WHERE ( `status` IN('In Progress', 'Completed') ) GROUP BY `file_uri`");
+        $db->expects($this->once())->method('fetch')->with("SELECT `file_uri` AS `fileUri`, GROUP_CONCAT(`id`) AS `ids` FROM `wp_smartling_submissions` WHERE ( `status` IN('In Progress', 'Completed') AND `is_cloned` <> '1' ) GROUP BY `file_uri`");
         $x = $this->subject;
         $x->method('getDbal')->willReturn($db);
         $x->getGroupedIdsByFileUri();


### PR DESCRIPTION
Cloned submissions were attempting to do a status check. No file is present, and this error is considered unrecoverable, failing the submission.