### PR TITLE
improve Gutenberg block support (WP-690)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -776,7 +776,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -838,7 +838,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -858,7 +858,7 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -925,7 +925,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -945,7 +945,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -1009,7 +1009,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1029,7 +1029,7 @@
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
@@ -1085,7 +1085,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1160,29 +1160,30 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -1209,7 +1210,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
             "funding": [
                 {
@@ -1225,29 +1226,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+            },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
@@ -1272,7 +1277,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
             "funding": [
                 {
@@ -1280,7 +1285,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1919,16 +1924,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.23",
+            "version": "8.5.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "efb20ff3623b9d09bf190a68fdfe574538a8d496"
+                "reference": "293cb0099d75407d971a73f41e51f35b664667ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/efb20ff3623b9d09bf190a68fdfe574538a8d496",
-                "reference": "efb20ff3623b9d09bf190a68fdfe574538a8d496",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/293cb0099d75407d971a73f41e51f35b664667ed",
+                "reference": "293cb0099d75407d971a73f41e51f35b664667ed",
                 "shasum": ""
             },
             "require": {
@@ -2000,7 +2005,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.23"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.24"
             },
             "funding": [
                 {
@@ -2012,7 +2017,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-21T05:50:34+00:00"
+            "time": "2022-03-05T16:52:36+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/inc/Smartling/Helpers/RelativeLinkedAttachmentCoreHelper.php
+++ b/inc/Smartling/Helpers/RelativeLinkedAttachmentCoreHelper.php
@@ -318,7 +318,7 @@ class RelativeLinkedAttachmentCoreHelper implements WPHookInterface
             $acfData = json_decode(stripslashes($block), true, 512, JSON_THROW_ON_ERROR);
             if (array_key_exists('data', $acfData)) {
                 foreach ($acfData['data'] as $key => $value) {
-                    if (array_key_exists($value, $this->acfDefinitions)
+                    if ((is_string($value) || is_int($value)) && array_key_exists($value, $this->acfDefinitions)
                         && array_key_exists('type', $this->acfDefinitions[$value])
                         && $this->acfDefinitions[$value]['type'] === 'image'
                         && strpos($key, '_') === 0

--- a/tests/Smartling/Helpers/GutenbergBlockHelperTest.php
+++ b/tests/Smartling/Helpers/GutenbergBlockHelperTest.php
@@ -359,40 +359,40 @@ HTML
                     'mode' => 'auto',
                 ],
                 [],
-                '<!-- wp:acf/sticky-cta {\"id\":\"block_5e46fa29a5a8e\",\"name\":\"acf\\\/sticky-cta\",' .
-                '\"data\":{\"copy\":\"Pronto para reservar seu próximo evento?\",\"cta_copy\":\"Obter uma cotação\"' .
-                ',\"cta_url\":\"https:\\\/\\\/www.test.com\\\/somePath\",\"sticky_behavior\":\"bottom\"},' .
-                '\"align\":\"\",\"mode\":\"auto\"} /-->'
+                '<!-- wp:acf/sticky-cta {"id":"block_5e46fa29a5a8e","name":"acf\/sticky-cta",' .
+                '"data":{"copy":"Pronto para reservar seu próximo evento?","cta_copy":"Obter uma cotação"' .
+                ',"cta_url":"https:\/\/www.test.com\/somePath","sticky_behavior":"bottom"},' .
+                '"align":"","mode":"auto"} /-->'
             ],
             'emojis' => [
                 'acf/test',
                 ['data' => ['copy' => 'Test 𝒞 and 😂, 絵文字, 👩‍🦽, ⚛️.']],
                 [],
-                '<!-- wp:acf/test {\"data\":{\"copy\":\"Test 𝒞 and 😂, 絵文字, 👩‍🦽, ⚛️.\"}} /-->'
+                '<!-- wp:acf/test {"data":{"copy":"Test 𝒞 and 😂, 絵文字, 👩‍🦽, ⚛️."}} /-->'
             ],
             'pre-encoded' => [
                 'acf/test',
                 ['data' => ['copy' => "Pronto para reservar seu pr\\u00f3ximo evento?"]],
                 [],
-                '<!-- wp:acf/test {\"data\":{\"copy\":\"Pronto para reservar seu pr\\\\\\\\u00f3ximo evento?\"}} /-->'
+                '<!-- wp:acf/test {"data":{"copy":"Pronto para reservar seu pr\\\\u00f3ximo evento?"}} /-->'
             ],
             'quotes as html entities' => [
                 'wework-blocks/geo-location',
                 ['showList' => '[{&quot;value&quot;:&quot;united-states&quot;,&quot;label&quot;:&quot;United States&quot;}]'],
                 [],
-                '<!-- wp:wework-blocks/geo-location {\"showList\":\"[{\\\\\\"value\\\\\\":\\\\\\"united-states\\\\\\",\\\\\\"label\\\\\\":\\\\\\"United States\\\\\\"}]\"} /-->',
+                '<!-- wp:wework-blocks/geo-location {"showList":"[{\\\\\\"value\\\\\\":\\\\\\"united-states\\\\\\",\\\\\\"label\\\\\\":\\\\\\"United States\\\\\\"}]"} /-->',
             ],
             'nested attributes' => [
                 'acf/image-text-wrap',
                 ['data' => ['content' => '[caption id=\u0022attachment_3000029563\u0022]\n\nText', '_content' => 'More text']],
                 [],
-                '<!-- wp:acf/image-text-wrap {\"data\":{\"content\":\"[caption id=\\\\\\\u0022attachment_3000029563\\\\\\\u0022]\\\\\\\n\\\\\\\nText\",\"_content\":\"More text\"}} /-->',
+                '<!-- wp:acf/image-text-wrap {"data":{"content":"[caption id=\\\u0022attachment_3000029563\\\u0022]\\\n\\\nText","_content":"More text"}} /-->',
             ],
             'root block' => [
                 'acf/offset-impact',
                 $blockForNestedTest,
                 [],
-                '<!-- wp:acf/offset-impact {\"id\":\"block_5fe115ebd752d\",\"name\":\"acf\\\\/offset-impact\",\"data\":{\"content\":\"<img class=\\\\\"alignnone size-medium wp-image-3000025130\\\\\" src=\\\\\"https:\\\\/\\\\/example.com\\\\/ideas\\\\/wp-content\\\\/uploads\\\\/sites\\\\/4\\\\/2020\\\\/12\\\\/GettyImages-1179050298_twitter-800x450.jpg\\\\\" alt=\\\\\"\\\\\" width=\\\\\"800\\\\\" height=\\\\\"450\\\\\" \\\\/>\",\"_content\":\"field_5d64117a9210b\",\"media\":\"3000025132\",\"_media\":\"field_5d64118f9210c\",\"add_video_url\":\"\",\"_add_video_url\":\"field_5eb3d3092a4ca\"},\"align\":\"\",\"mode\":\"auto\",\"wpClassName\":\"wp-block-acf-offset-impact\"} /-->',
+                '<!-- wp:acf/offset-impact {"id":"block_5fe115ebd752d","name":"acf\/offset-impact","data":{"content":"<img class=\"alignnone size-medium wp-image-3000025130\" src=\"https:\/\/example.com\/ideas\/wp-content\/uploads\/sites\/4\/2020\/12\/GettyImages-1179050298_twitter-800x450.jpg\" alt=\"\" width=\"800\" height=\"450\" \/>","_content":"field_5d64117a9210b","media":"3000025132","_media":"field_5d64118f9210c","add_video_url":"","_add_video_url":"field_5eb3d3092a4ca"},"align":"","mode":"auto","wpClassName":"wp-block-acf-offset-impact"} /-->',
             ],
             'nested block' => [
                 'acf/offset-impact',
@@ -454,7 +454,7 @@ HTML
     public function testRenderTranslatedBlockNode()
     {
         $xmlPart = '<gutenbergBlock blockName="core/foo" originalAttributes="YToxOntzOjQ6ImRhdGEiO2E6Mzp7czo2OiJ0ZXh0X2EiO3M6NzoiVGl0bGUgMSI7czo2OiJ0ZXh0X2IiO3M6NzoiVGl0bGUgMiI7czo1OiJ0ZXh0cyI7YToyOntpOjA7czo1OiJsb3JlbSI7aToxO3M6NToiaXBzdW0iO319fQ=="><![CDATA[]]><contentChunk hash="d3d67cc32ac556aae106e606357f449e"><![CDATA[<p>Inner HTML</p>]]></contentChunk><blockAttribute name="data/text_a" hash="90bc6d3874182275bd4cd88cbd734fe9"><![CDATA[Title 1]]></blockAttribute><blockAttribute name="data/text_b" hash="e4bb56dda4ecb60c34ccb89fd50506df"><![CDATA[Title 2]]></blockAttribute><blockAttribute name="data/texts/0" hash="d2e16e6ef52a45b7468f1da56bba1953"><![CDATA[lorem]]></blockAttribute><blockAttribute name="data/texts/1" hash="e78f5438b48b39bcbdea61b73679449d"><![CDATA[ipsum]]></blockAttribute></gutenbergBlock>';
-        $expectedBlock = '<!-- wp:core/foo {\"data\":{\"text_a\":\"Title 1\",\"text_b\":\"Title 2\",\"texts\":[\"lorem\",\"ipsum\"]}} --><p>Inner HTML</p><!-- /wp:core/foo -->';
+        $expectedBlock = '<!-- wp:core/foo {"data":{"text_a":"Title 1","text_b":"Title 2","texts":["lorem","ipsum"]}} --><p>Inner HTML</p><!-- /wp:core/foo -->';
 
         $dom = new \DOMDocument('1.0', 'utf8');
         $dom->loadXML($xmlPart);


### PR DESCRIPTION
Simplified and improved slashing, should now only add slashes for ACF, because ACF strips slashes from own blocks.
Fixed issues when a block's property was an array.
