### PR TITLE
add meta values normalization for taxonomies (WP-704)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "2.12.6",
+  "version": "2.12.7",
   "description": "",
   "type": "wordpress-plugin",
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "780c3bcdc9e67c5b2d808c6ff465b0ec",
+    "content-hash": "ef9c00c8f265b230ceed2a85006fd69b",
     "packages": [
         {
             "name": "galbar/jsonpath",
@@ -1977,16 +1977,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.25",
+            "version": "8.5.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9ff23f4dfde040ccd3b8db876192d1184b934158"
+                "reference": "ef117c59fc4c54a979021b26d08a3373e386606d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ff23f4dfde040ccd3b8db876192d1184b934158",
-                "reference": "9ff23f4dfde040ccd3b8db876192d1184b934158",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ef117c59fc4c54a979021b26d08a3373e386606d",
+                "reference": "ef117c59fc4c54a979021b26d08a3373e386606d",
                 "shasum": ""
             },
             "require": {
@@ -2058,7 +2058,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.25"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.26"
             },
             "funding": [
                 {
@@ -2070,7 +2070,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-16T16:24:13+00:00"
+            "time": "2022-04-01T12:34:39+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2922,5 +2922,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
@@ -154,79 +154,13 @@ class PostEntityStd extends EntityAbstract
         return new WordpressFunctionProxyHelper();
     }
 
-    /**
-     * @param array $metadata
-     * @return bool
-     */
-    private function areMetadataValuesUnique(array $metadata)
-    {
-        $valueHash = function ($value) {
-            return md5(serialize($value));
-        };
-
-        if (1 < count($metadata)) {
-            $firstHash = $valueHash(array_shift($metadata));
-            foreach ($metadata as $metadatum) {
-                if ($valueHash($metadatum) !== $firstHash) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * @param array $metadata
-     * @return array
-     */
-    private function formatMetadata(array $metadata)
-    {
-        foreach ($metadata as & $mValue) {
-            if (!$this->areMetadataValuesUnique($mValue)) {
-                $mValue = ArrayHelper::first($mValue);
-            } else {
-                $msg = vsprintf(
-                    'Detected unsupported metadata: \'%s\' for entity %s=\'%s\'',
-                    [
-                        \json_encode($metadata),
-                        $this->getPrimaryFieldName(),
-                        $this->getPK(),
-                    ]
-                );
-                $this->getLogger()->warning($msg);
-
-                /**
-                 * Get last value
-                 */
-                $lastValue = ArrayHelper::last($mValue);
-
-                $msg = vsprintf(
-                    'Got unsupported metadata \'%s\' for post ID=\'%s\' Continue using last value = \'%s\'.',
-                    [
-                        \json_encode($mValue),
-                        $this->getPK(),
-                        $lastValue,
-                    ]
-                );
-
-                $this->getLogger()->warning($msg);
-
-                $mValue = $lastValue;
-            }
-        }
-
-        return $metadata;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getMetadata()
+    public function getMetadata(): array
     {
         $metadata = $this->getWpProxyHelper()->getPostMeta($this->ID);
 
-        if ((is_array($metadata) && 0 === count($metadata)) || !is_array($metadata)) {
+        if (!is_array($metadata) || 0 === count($metadata)) {
             $this->rawLogPostMetadata($this->ID);
+            return [];
         }
 
         return $this->formatMetadata($metadata);

--- a/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
@@ -83,10 +83,7 @@ class WidgetEntity extends VirtualEntityAbstract
         throw new \BadMethodCallException($message);
     }
 
-    /**
-     * @return array;
-     */
-    public function getMetadata()
+    public function getMetadata(): array
     {
         return [];
     }

--- a/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
+++ b/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
@@ -72,10 +72,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
         throw new \BadMethodCallException($message);
     }
 
-    /**
-     * @return array;
-     */
-    public function getMetadata()
+    public function getMetadata(): array
     {
         return [];
     }

--- a/inc/Smartling/Helpers/WordpressFunctionProxyHelper.php
+++ b/inc/Smartling/Helpers/WordpressFunctionProxyHelper.php
@@ -24,6 +24,11 @@ class WordpressFunctionProxyHelper
         return get_taxonomies(...func_get_args());
     }
 
+    public function get_term_meta()
+    {
+        return get_term_meta(...func_get_args());
+    }
+
     public function getPostMeta($postId)
     {
         return get_post_meta($postId);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 5.9
 Requires PHP: 7.4
-Stable tag: 2.12.6
+Stable tag: 2.12.7
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 2.12.7 =
+* Fixed terms meta values stored as array instead of scalar values
+
 = 2.12.6 =
 * Added purge upload queue action (sets all NEW submissions to CANCELLED)
 * Fixed smartlingLockId attribute being sent for translation

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           2.12.6
+ * Version:           2.12.7
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStdTest.php
+++ b/tests/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStdTest.php
@@ -8,9 +8,9 @@ use Smartling\Helpers\WordpressFunctionProxyHelper;
 
 class TaxonomyEntityStdTest extends TestCase {
     /**
-     * Metadata values for taxonomies should not be stored as array for scalar values
+     * @see https://bt.smartling.net/browse/WP-704
      */
-    public function testWP704()
+    public function testTermMetadataStoredAsScalars()
     {
         $logoField = 'field_609bacf18fec4';
         $logoId = 33404;
@@ -18,8 +18,18 @@ class TaxonomyEntityStdTest extends TestCase {
         $websiteLink = '';
 
         $wp = $this->createMock(WordpressFunctionProxyHelper::class);
-        $wp->method('get_term_meta')->willReturn(['logo' => [$logoId], '_logo' => [$logoField], 'website_link' => [$websiteLink], '_website_link' => [$websiteField]]);
-        $x = new TaxonomyEntityStd('category', [], $wp);
-        $this->assertEquals(['logo' => $logoId, '_logo' => $logoField, 'website_link' => $websiteLink, '_website_link' => $websiteField], $x->getMetadata());
+        $wp->method('get_term_meta')->willReturn([
+            'logo' => [$logoId],
+            '_logo' => [$logoField],
+            'website_link' => [$websiteLink],
+            '_website_link' => [$websiteField]
+        ]);
+
+        $this->assertEquals([
+            'logo' => $logoId,
+            '_logo' => $logoField,
+            'website_link' => $websiteLink,
+            '_website_link' => $websiteField
+        ], (new TaxonomyEntityStd('category', [], $wp))->getMetadata());
     }
 }

--- a/tests/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStdTest.php
+++ b/tests/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStdTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Smartling\Tests\Smartling\DbAl\WordpressContentEntities;
+
+use PHPUnit\Framework\TestCase;
+use Smartling\DbAl\WordpressContentEntities\TaxonomyEntityStd;
+use Smartling\Helpers\WordpressFunctionProxyHelper;
+
+class TaxonomyEntityStdTest extends TestCase {
+    /**
+     * Metadata values for taxonomies should not be stored as array for scalar values
+     */
+    public function testWP704()
+    {
+        $logoField = 'field_609bacf18fec4';
+        $logoId = 33404;
+        $websiteField = 'field_611e6178a7cee';
+        $websiteLink = '';
+
+        $wp = $this->createMock(WordpressFunctionProxyHelper::class);
+        $wp->method('get_term_meta')->willReturn(['logo' => [$logoId], '_logo' => [$logoField], 'website_link' => [$websiteLink], '_website_link' => [$websiteField]]);
+        $x = new TaxonomyEntityStd('category', [], $wp);
+        $this->assertEquals(['logo' => $logoId, '_logo' => $logoField, 'website_link' => $websiteLink, '_website_link' => $websiteField], $x->getMetadata());
+    }
+}


### PR DESCRIPTION
The issue is that WordPress returns an array of values for get_term_meta, and we need to normalize this array just as is done for posts