### PR TITLE
add release version check (WP-712)

### DIFF
--- a/Buildplan/Dockerfile-Jenkins
+++ b/Buildplan/Dockerfile-Jenkins
@@ -67,9 +67,8 @@ ENV COMPOSER_H_DIR="${HOME}/.composer"
 ENV PLUGIN_DIR="${WP_PLUGINS_DIR}/smartling-connector"
 ENV LOCAL_GIT_DIR="/plugin-dir"
 
-COPY Buildplan/release.sh /release.sh
-COPY Buildplan/test.sh /test.sh
-RUN chmod +x /release.sh /test.sh
+COPY Buildplan/release.sh Buildplan/releaseVersionCheck.sh /test.sh /
+RUN chmod +x /release.sh /releaseVersionCheck.sh /test.sh
 
 RUN service mysql start && cd ${WP_INSTALL_DIR} && \
     if [ ! -d "${COMPOSER_H_DIR}" ]; then mkdir "${COMPOSER_H_DIR}"; fi; echo "{\"github-oauth\":{\"github.com\":\"$GITHUB_OAUTH_TOKEN\"}}" > "${COMPOSER_H_DIR}/auth.json" && \

--- a/Buildplan/Dockerfile-Jenkins
+++ b/Buildplan/Dockerfile-Jenkins
@@ -67,7 +67,7 @@ ENV COMPOSER_H_DIR="${HOME}/.composer"
 ENV PLUGIN_DIR="${WP_PLUGINS_DIR}/smartling-connector"
 ENV LOCAL_GIT_DIR="/plugin-dir"
 
-COPY Buildplan/release.sh Buildplan/releaseVersionCheck.sh /test.sh /
+COPY Buildplan/release.sh Buildplan/releaseVersionCheck.sh Buildplan/test.sh /
 RUN chmod +x /release.sh /releaseVersionCheck.sh /test.sh
 
 RUN service mysql start && cd ${WP_INSTALL_DIR} && \

--- a/Buildplan/Dockerfile-Jenkins
+++ b/Buildplan/Dockerfile-Jenkins
@@ -67,8 +67,8 @@ ENV COMPOSER_H_DIR="${HOME}/.composer"
 ENV PLUGIN_DIR="${WP_PLUGINS_DIR}/smartling-connector"
 ENV LOCAL_GIT_DIR="/plugin-dir"
 
-COPY Buildplan/release.sh Buildplan/releaseVersionCheck.sh Buildplan/test.sh /
-RUN chmod +x /release.sh /releaseVersionCheck.sh /test.sh
+COPY Buildplan/*.sh /
+RUN chmod +x /*.sh
 
 RUN service mysql start && cd ${WP_INSTALL_DIR} && \
     if [ ! -d "${COMPOSER_H_DIR}" ]; then mkdir "${COMPOSER_H_DIR}"; fi; echo "{\"github-oauth\":{\"github.com\":\"$GITHUB_OAUTH_TOKEN\"}}" > "${COMPOSER_H_DIR}/auth.json" && \

--- a/Buildplan/releaseVersionCheck.sh
+++ b/Buildplan/releaseVersionCheck.sh
@@ -4,5 +4,5 @@ COMPOSER_VERSION=`grep '"version"' composer.json | sed 's/  "version": "\(.\+\)"
 STABLE_TAG=`grep 'Stable tag:' readme.txt | sed 's/Stable tag: //'`
 if [ "$CONNECTOR_VERSION" != "$COMPOSER_VERSION" ] || [ "$COMPOSER_VERSION" != "$STABLE_TAG" ]; then
   echo "Version mismatch: connectorVersion=$CONNECTOR_VERSION, stableTag=$STABLE_TAG, composerVersion=$COMPOSER_VERSION"
-  exit(1);
+  exit 1;
 fi

--- a/Buildplan/releaseVersionCheck.sh
+++ b/Buildplan/releaseVersionCheck.sh
@@ -3,6 +3,6 @@ cd trunk
 CONNECTOR_VERSION=`grep '* Version' smartling-connector.php | sed 's/ \\* Version: *//'`
 COMPOSER_VERSION=`grep '"version"' composer.json | sed 's/  "version": "(\d+\.\d+\.\d+)"*/\1/'`
 STABLE_TAG=`grep 'Stable tag:' readme.txt | sed 's/Stable tag: //'`
-echo CONNECTOR_VERSION
-echo COMPOSER_VERSION
-echo STABLE_TAG
+echo $CONNECTOR_VERSION
+echo $COMPOSER_VERSION
+echo $STABLE_TAG

--- a/Buildplan/releaseVersionCheck.sh
+++ b/Buildplan/releaseVersionCheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 CONNECTOR_VERSION=`grep '* Version' smartling-connector.php | sed 's/ \\* Version: *//'`
-COMPOSER_VERSION=`grep '"version"' composer.json | sed 's/  "version": "\(.\+\)"*/\1/'`
+COMPOSER_VERSION=`grep '"version"' composer.json | sed 's/  "version": "\(.\+\)",/\1/'`
 STABLE_TAG=`grep 'Stable tag:' readme.txt | sed 's/Stable tag: //'`
 if [ "$CONNECTOR_VERSION" != "$COMPOSER_VERSION" ] || [ "$COMPOSER_VERSION" != "$STABLE_TAG" ]; then
   echo "Version mismatch: connectorVersion=$CONNECTOR_VERSION, stableTag=$STABLE_TAG, composerVersion=$COMPOSER_VERSION"

--- a/Buildplan/releaseVersionCheck.sh
+++ b/Buildplan/releaseVersionCheck.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 CONNECTOR_VERSION=`grep '* Version' smartling-connector.php | sed 's/ \\* Version: *//'`
-COMPOSER_VERSION=`grep '"version"' composer.json | sed 's/  "version": "\(.+\)"*/\1/'`
+COMPOSER_VERSION=`grep '"version"' composer.json | sed 's/  "version": "\(.\+\)"*/\1/'`
 STABLE_TAG=`grep 'Stable tag:' readme.txt | sed 's/Stable tag: //'`
-echo $CONNECTOR_VERSION
-echo $COMPOSER_VERSION
-echo $STABLE_TAG
+if [ "$CONNECTOR_VERSION" != "$COMPOSER_VERSION" ] || [ "$COMPOSER_VERSION" != "$STABLE_TAG" ]; then
+  echo "Version mismatch: connectorVersion=$CONNECTOR_VERSION, stableTag=$STABLE_TAG, composerVersion=$COMPOSER_VERSION"
+  exit(1);
+fi

--- a/Buildplan/releaseVersionCheck.sh
+++ b/Buildplan/releaseVersionCheck.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+cd trunk
+CONNECTOR_VERSION=`grep '* Version' smartling-connector.php | sed 's/ \\* Version: *//'`
+COMPOSER_VERSION=`grep '"version"' composer.json | sed 's/  "version": "(\d+\.\d+\.\d+)"*/\1/'`
+STABLE_TAG=`grep 'Stable tag:' readme.txt | sed 's/Stable tag: //'`
+echo CONNECTOR_VERSION
+echo COMPOSER_VERSION
+echo STABLE_TAG

--- a/Buildplan/releaseVersionCheck.sh
+++ b/Buildplan/releaseVersionCheck.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-cd trunk
 CONNECTOR_VERSION=`grep '* Version' smartling-connector.php | sed 's/ \\* Version: *//'`
-COMPOSER_VERSION=`grep '"version"' composer.json | sed 's/  "version": "(\d+\.\d+\.\d+)"*/\1/'`
+COMPOSER_VERSION=`grep '"version"' composer.json | sed 's/  "version": "\(.+\)"*/\1/'`
 STABLE_TAG=`grep 'Stable tag:' readme.txt | sed 's/Stable tag: //'`
 echo $CONNECTOR_VERSION
 echo $COMPOSER_VERSION

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,18 +18,6 @@ pipeline {
             }
         }
 
-        stage('Release version check') {
-            agent {
-                label 'master'
-            }
-
-            steps {
-                dir('.') {
-                    sh 'docker run --rm -w /plugin-dir -v $PWD:/plugin-dir wordpress-localization-plugin-php74:latest /releaseVersionCheck.sh'
-                }
-            }
-        }
-
         stage('Run tests') {
             agent {
                 label 'master'
@@ -51,6 +39,18 @@ pipeline {
 
             steps {
                 archiveArtifacts artifacts: 'release.zip'
+            }
+        }
+
+        stage('Release version check') {
+            agent {
+                label 'master'
+            }
+
+            steps {
+                dir('.') {
+                    sh 'docker run --rm -w /plugin-dir -v $PWD:/plugin-dir wordpress-localization-plugin-php74:latest /releaseVersionCheck.sh'
+                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,18 @@ pipeline {
             }
         }
 
+        stage('Release version check') {
+            agent {
+                label 'master'
+            }
+
+            steps {
+                dir('.') {
+                    sh 'docker run --rm -w /plugin-dir -v $PWD:/plugin-dir /releaseVersionCheck.sh'
+                }
+            }
+        }
+
         stage('Run tests') {
             agent {
                 label 'master'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
 
             steps {
                 dir('.') {
-                    sh 'docker run --rm -w /plugin-dir -v $PWD:/plugin-dir /releaseVersionCheck.sh'
+                    sh 'docker run --rm -w /plugin-dir -v $PWD:/plugin-dir wordpress-localization-plugin-php74:latest /releaseVersionCheck.sh'
                 }
             }
         }


### PR DESCRIPTION
It is possible to release a non-stable version, and the process of reverting such a release is non-trivial. I remember the idea of releasing by GH tag, but it needs more effort, and would be prone to the same mistake too