### PR TITLE
fix ExternalContentManager error handling (WP-746)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "",
   "type": "wordpress-plugin",
   "require": {

--- a/inc/Smartling/ContentTypes/ExternalContentManager.php
+++ b/inc/Smartling/ContentTypes/ExternalContentManager.php
@@ -34,13 +34,13 @@ class ExternalContentManager
                 $this->getLogger()->debug("Determined support for {$handler->getPluginId()}, will try to get fields");
                 try {
                     $source[$handler->getPluginId()] = $handler->getContentFields($submission, $raw);
-                } catch (\Error $e) {
+                } catch (\Throwable $e) {
                     $this->getLogger()->notice('HandlerName="' . $handler->getPluginId() . '" got exception while trying to get external content: ' . $e->getMessage());
                 }
                 if ($handler instanceof ContentTypeModifyingInterface) {
                     try {
                         $source = $handler->alterContentFieldsForUpload($source);
-                    } catch (\Error $e) {
+                    } catch (\Throwable $e) {
                         $this->getLogger()->notice('HandlerName="' . $handler->getPluginId() . '" got exception while trying to alter content fields: ' . $e->getMessage());
                     }
                 }
@@ -78,7 +78,7 @@ class ExternalContentManager
                         $this->getLogger()->info('Content array modified by HandlerName="' . $handler->getPluginId() . '"');
                         $translation = $externalContent;
                     }
-                } catch (\Error $e) {
+                } catch (\Throwable $e) {
                     $this->getLogger()->notice('HandlerName="' . $handler->getPluginId() . '" got exception while trying to set external content: ' . $e->getMessage());
                 }
             }

--- a/inc/Smartling/Services/ContentRelationsDiscoveryService.php
+++ b/inc/Smartling/Services/ContentRelationsDiscoveryService.php
@@ -557,7 +557,12 @@ class ContentRelationsDiscoveryService
         }
         $detectedReferences = array_merge_recursive($detectedReferences, $this->externalContentManager->getExternalRelations($contentType, $id));
 
-        $this->getLogger()->debug(self::POST_BASED_PROCESSOR . ' has ' . (count($detectedReferences[self::POST_BASED_PROCESSOR], COUNT_RECURSIVE) ?? 0) . ' references');
+        $message = self::POST_BASED_PROCESSOR . ' has %d references';
+        $count = 0;
+        if (array_key_exists(self::POST_BASED_PROCESSOR, $detectedReferences)) {
+            $count = count($detectedReferences[self::POST_BASED_PROCESSOR], COUNT_RECURSIVE);
+        }
+        $this->getLogger()->debug(sprintf($message, $count));
         $detectedReferences = $this->normalizeReferences($detectedReferences);
 
         $responseData = new DetectedRelations($detectedReferences);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 6.0
 Requires PHP: 7.4
-Stable tag: 2.14.1
+Stable tag: 2.14.2
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 2.14.2 =
+* Fixed issue where content without Elementor data was unable to be sent for translation
+
 = 2.14.1 =
 * Added sending related attachments for translation along with Elementor plugin content
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           2.14.1
+ * Version:           2.14.2
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/Smartling/ContentTypes/ExternalContentManagerTest.php
+++ b/tests/Smartling/ContentTypes/ExternalContentManagerTest.php
@@ -10,6 +10,25 @@ use Smartling\Helpers\PluginHelper;
 use Smartling\Submissions\SubmissionEntity;
 
 class ExternalContentManagerTest extends TestCase {
+    public function testExceptionHandling()
+    {
+        $content1 = $this->createMock(ContentTypePluggableInterface::class);
+        $content1->method('canHandle')->willReturn(true);
+        $content1->method('getContentFields')->willThrowException(new \JsonException());
+        $content1->method('setRelatedContent')->willThrowException(new \RuntimeException());
+        $content1->method('getRelatedContent')->willThrowException(new \Exception());
+        $content2 = $this->createMock(ContentTypeModifyingInterface::class);
+        $content2->method('canHandle')->willReturn(true);
+        $content2->method('getContentFields')->willThrowException(new \TypeError());
+        $content2->method('setRelatedContent')->willThrowException(new \Error());
+        $content2->method('getRelatedContent')->willThrowException(new \ParseError());
+        $x = new ExternalContentManager(new PluginHelper());
+        $submission = $this->createMock(SubmissionEntity::class);
+        $this->assertEquals([], $x->getExternalContent([], $submission, false));
+        $this->assertEquals([], $x->getExternalRelations('post', 1));
+        $this->assertEquals([], $x->setExternalContent([], [], $submission));
+    }
+
     public function testGetExternalContentNotAltered()
     {
         $content1 = $this->createMock(ContentTypePluggableInterface::class);


### PR DESCRIPTION
Visibility PR, I mistakengly thought Exception is a subset of Error, so any exceptions inside external content handlers could break the translation flow.