### PR TITLE
fix metadata escaping (WP-747)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "",
   "type": "wordpress-plugin",
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24be5fd8f5f7228c03dc70f5f1232924",
+    "content-hash": "dbc19d0b0dd2acc139ca8b25bd702cf7",
     "packages": [
         {
             "name": "galbar/jsonpath",
@@ -2963,5 +2963,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/inc/Smartling/ContentTypes/ExternalContentElementor.php
+++ b/inc/Smartling/ContentTypes/ExternalContentElementor.php
@@ -305,11 +305,11 @@ class ExternalContentElementor extends ExternalContentAbstract implements Conten
 
     public function setContentFields(array $original, array $translation, SubmissionEntity $submission): array
     {
-        $translation['meta']['_elementor_data'] = addslashes(json_encode($this->mergeElementorData(
+        $translation['meta']['_elementor_data'] = json_encode($this->mergeElementorData(
             json_decode($original['meta']['_elementor_data'] ?? '[]', true, 512, JSON_THROW_ON_ERROR),
             $this->fieldsFilterHelper->flattenArray($translation[$this->getPluginId()] ?? []),
             $submission,
-        ), JSON_THROW_ON_ERROR));
+        ), JSON_THROW_ON_ERROR);
         unset($translation[$this->getPluginId()]);
         return $translation;
     }

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
@@ -241,7 +241,7 @@ abstract class EntityAbstract
      * @param string $tagValue
      * @param bool   $unique
      */
-    abstract public function setMetaTag($tagName, $tagValue, $unique = true);
+    abstract public function setMetaTag($tagName, $tagValue, $unique = true): void;
 
     /**
      * @param int $limit

--- a/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
@@ -369,8 +369,12 @@ class PostEntityStd extends EntityAbstract
          * Tag name and value expected to be slashed
          * @see add_metadata()
          */
-        $tagName = addslashes($tagName);
-        $tagValue = addslashes($tagValue);
+        if (is_string($tagName)) {
+            $tagName = addslashes($tagName);
+        }
+        if (is_string($tagValue)) {
+            $tagValue = addslashes($tagValue);
+        }
         if (false === ($result = add_post_meta($this->ID, $tagName, $tagValue, $unique))) {
             $result = update_post_meta($this->ID, $tagName, $tagValue);
         }

--- a/inc/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStd.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStd.php
@@ -52,7 +52,7 @@ class TaxonomyEntityStd extends EntityAbstract
         return $this->formatMetadata($metadata);
     }
 
-    public function setMetaTag($tagName, $tagValue, $unique = true)
+    public function setMetaTag($tagName, $tagValue, $unique = true): void
     {
         $curValue = get_term_meta($this->getPK(), $tagName, $unique);
 

--- a/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
@@ -124,7 +124,7 @@ class WidgetEntity extends VirtualEntityAbstract
      * @param string $tagValue
      * @param bool   $unique
      */
-    public function setMetaTag($tagName, $tagValue, $unique = true)
+    public function setMetaTag($tagName, $tagValue, $unique = true): void
     {
     }
 

--- a/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
+++ b/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
@@ -101,7 +101,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
      * @param string $tagValue
      * @param bool   $unique
      */
-    public function setMetaTag($tagName, $tagValue, $unique = true)
+    public function setMetaTag($tagName, $tagValue, $unique = true): void
     {
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 6.0
 Requires PHP: 7.4
-Stable tag: 2.14.2
+Stable tag: 2.14.3
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 2.14.3 =
+* Fixed errors when saving metadata by improving the escaping process
+
 = 2.14.2 =
 * Fixed issue where content without Elementor data was unable to be sent for translation
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           2.14.2
+ * Version:           2.14.3
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/Smartling/ContentTypes/ExternalContentElementorTest.php
+++ b/tests/Smartling/ContentTypes/ExternalContentElementorTest.php
@@ -96,11 +96,11 @@ class ExternalContentElementorTest extends TestCase {
             $x->setContentFields(['meta' => ['_elementor_data' => '[]']], ['elementor' => []], $this->createMock(SubmissionEntity::class))
         );
         $original = '[{"id":"590657a","elType":"section","settings":{"structure":"30"},"elements":[{"id":"b56da21","elType":"column","settings":{"_column_size":33,"_inline_size":null},"elements":[{"id":"c799791","elType":"widget","settings":{"editor":"<p>Left text<\/p>"},"elements":[],"widgetType":"text-editor"}],"isInner":false},{"id":"0f3ad3c","elType":"column","settings":{"_column_size":33,"_inline_size":null},"elements":[{"id":"0088b31","elType":"widget","settings":{"editor":"<p>Middle text<\/p>"},"elements":[],"widgetType":"text-editor"}],"isInner":false},{"id":"8798127","elType":"column","settings":{"_column_size":33,"_inline_size":null},"elements":[{"id":"78d53a1","elType":"widget","settings":{"title":"Right heading"},"elements":[],"widgetType":"heading"}],"isInner":false}],"isInner":false},{"id":"7a874c7","elType":"section","settings":[],"elements":[{"id":"d7d603e","elType":"column","settings":{"_column_size":100,"_inline_size":null},"elements":[{"id":"ea10188","elType":"widget","settings":{"image":{"url":"http:\/\/localhost.localdomain\/wp-content\/uploads\/2021\/09\/elementor-image.png","id":' . $sourceAttachmentId . ',"alt":"","source":"library"},"image_size":"medium"},"elements":[],"widgetType":"image"}],"isInner":false}],"isInner":false}]';
-        $expected = addslashes(str_replace(
+        $expected = str_replace(
             ['<p>Left text<\/p>', '<p>Middle text<\/p>', 'Right heading', $sourceAttachmentId],
             ['<p>Left text translated<\/p>', '<p>Middle text translated<\/p>', 'Right heading translated', $targetAttachmentId],
             $original
-        ));
+        );
 
         $this->assertEquals(
             ['meta' => ['_elementor_data' => $expected]],


### PR DESCRIPTION
Previously, a fix was applied to lessen the amount of escaping-related issues while saving post_content field. It worked, and now it appears we need to rollout the same for meta fields and other relevant post fields