### PR TITLE
demote logging (WP-767)

### DIFF
--- a/inc/Smartling/Helpers/GutenbergBlockHelper.php
+++ b/inc/Smartling/Helpers/GutenbergBlockHelper.php
@@ -23,6 +23,7 @@ class GutenbergBlockHelper extends SubstringProcessorHelperAbstract
     protected const BLOCK_NODE_NAME = 'gutenbergBlock';
     protected const CHUNK_NODE_NAME = 'contentChunk';
     protected const ATTRIBUTE_NODE_NAME = 'blockAttribute';
+    private const CDATA_SECTION_NODE_NAME = '#cdata-section';
     private const MAX_NODE_DEPTH = 10;
 
     private AcfDynamicSupport $acfDynamicSupport;
@@ -371,14 +372,17 @@ class GutenbergBlockHelper extends SubstringProcessorHelperAbstract
              */
 
             switch ($childNode->nodeName) {
-                case static::BLOCK_NODE_NAME :
+                case static::BLOCK_NODE_NAME:
                     $chunks[] = $this->renderTranslatedBlockNode($childNode, $submission, $depth);
                     break;
-                case static::CHUNK_NODE_NAME :
+                case static::CHUNK_NODE_NAME:
                     $chunks[] = $childNode->nodeValue;
                     break;
-                case static::ATTRIBUTE_NODE_NAME :
+                case static::ATTRIBUTE_NODE_NAME:
                     $attrs[$childNode->getAttribute('name')] = $childNode->nodeValue;
+                    break;
+                case self::CDATA_SECTION_NODE_NAME:
+                    // processing by this helper is not needed, processed in self::CHUNK_NODE_NAME
                     break;
                 default:
                     $this->getLogger()->notice(

--- a/inc/Smartling/Helpers/MetaFieldProcessor/CloneValueFieldProcessor.php
+++ b/inc/Smartling/Helpers/MetaFieldProcessor/CloneValueFieldProcessor.php
@@ -57,7 +57,7 @@ class CloneValueFieldProcessor extends MetaFieldProcessorAbstract
         } else {
             $this->getLogger()->debug(
                 vsprintf(
-                    "Metadata='%s' for submissionId='%s' not found in source metadata. Keeping value='%s'",
+                    'Metadata="%s" for submissionId="%s" not found in source metadata. Keeping value="%s"',
                     [$fieldName, $submission->getId(), var_export($value, true),]
                 )
             );

--- a/inc/Smartling/Helpers/MetaFieldProcessor/CloneValueFieldProcessor.php
+++ b/inc/Smartling/Helpers/MetaFieldProcessor/CloneValueFieldProcessor.php
@@ -41,7 +41,7 @@ class CloneValueFieldProcessor extends MetaFieldProcessorAbstract
     public function processFieldPostTranslation(SubmissionEntity $submission, $fieldName, $value)
     {
         $originalMetadata = $this->getContentHelper()->readSourceMetadata($submission);
-        $metaFieldName = str_replace('meta/','',$fieldName);
+        $metaFieldName = str_replace('meta/','', $fieldName);
 
         if (array_key_exists($metaFieldName, $originalMetadata)) {
             $originalValue = $originalMetadata[$metaFieldName];
@@ -55,9 +55,9 @@ class CloneValueFieldProcessor extends MetaFieldProcessorAbstract
             }
             $value = $originalValue;
         } else {
-            $this->getLogger()->warning(
+            $this->getLogger()->debug(
                 vsprintf(
-                    'Cannot clone value of metadata=\'%s\' for submission=\'%s\'. Keeping value=%s',
+                    "Metadata='%s' for submissionId='%s' not found in source metadata. Keeping value='%s'",
                     [$fieldName, $submission->getId(), var_export($value, true),]
                 )
             );


### PR DESCRIPTION
I've examined previous logs, notices regarding cdata sections were present for quite a long time, as well as cloning failure messages. Cdata sections are actually processed along with content chunks. Failures to clone arise due to MetaFieldProcessor trying to process fields from Gutenberg blocks as metadata, but I can't imagine a proper fix for this condition right now