### PR TITLE
add exception handling in UploadJob (WP-776)

### DIFF
--- a/inc/Smartling/Jobs/UploadJob.php
+++ b/inc/Smartling/Jobs/UploadJob.php
@@ -50,7 +50,7 @@ class UploadJob extends JobAbstract
 
             try {
                 do_action(ExportedAPI::ACTION_SMARTLING_SEND_FILE_FOR_TRANSLATION, $entity);
-            } catch (\Error $e) {
+            } catch (\Exception $e) {
                 $this->getLogger()->notice(sprintf('Failing submissionId=%s: %s', $entity->getId(), $e->getMessage()));
                 $this->submissionManager->setErrorMessage($entity, $e->getMessage());
             }

--- a/inc/Smartling/Jobs/UploadJob.php
+++ b/inc/Smartling/Jobs/UploadJob.php
@@ -31,14 +31,7 @@ class UploadJob extends JobAbstract
 
     private function processUploadQueue(): void
     {
-        do {
-            $entities = $this->submissionManager->findSubmissionsForUploadJob();
-
-            if (0 === count($entities)) {
-                break;
-            }
-
-            $entity = ArrayHelper::first($entities);
+        while (($entity = $this->submissionManager->findSubmissionForUploadJob()) !== null) {
             $this->getLogger()->info(
                 vsprintf(
                     'Cron Job triggers content upload for submission id="%s" with status="%s" for entity="%s", blog="%s", id="%s", targetBlog="%s", locale="%s", batchUid="%s".',
@@ -55,9 +48,14 @@ class UploadJob extends JobAbstract
                 )
             );
 
-            do_action(ExportedAPI::ACTION_SMARTLING_SEND_FILE_FOR_TRANSLATION, $entity);
+            try {
+                do_action(ExportedAPI::ACTION_SMARTLING_SEND_FILE_FOR_TRANSLATION, $entity);
+            } catch (\Error $e) {
+                $this->getLogger()->notice(sprintf('Failing submissionId=%s: %s', $entity->getId(), $e->getMessage()));
+                $this->submissionManager->setErrorMessage($entity, $e->getMessage());
+            }
             $this->placeLockFlag(true);
-        } while (0 < count($entities));
+        }
     }
 
     private function processCloning(): void

--- a/inc/Smartling/Submissions/SubmissionManager.php
+++ b/inc/Smartling/Submissions/SubmissionManager.php
@@ -293,9 +293,8 @@ class SubmissionManager extends EntityManagerAbstract
 
     /**
      * Looks for submissions with status = 'New' AND batch_uid <> '' AND is_locked = 0
-     * @return SubmissionEntity[] with a single item or empty array
      */
-    public function findSubmissionsForUploadJob(): array
+    public function findSubmissionForUploadJob(): ?SubmissionEntity
     {
         $pageOptions = ['limit' => 1, 'page' => 1];
 
@@ -307,7 +306,7 @@ class SubmissionManager extends EntityManagerAbstract
             $pageOptions
         );
 
-        return $this->fetchData($query);
+        return $this->fetchData($query)[0] ?? null;
     }
 
     public function findSubmissionForCloning(): ?SubmissionEntity

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,7 @@ Additional information on the Smartling Connector for WordPress can be found [he
 == Changelog ==
 = 3.0.0 =
 * Minimum required PHP version is now 8.0!
+* Fixed upload queue getting stuck
 
 = 2.16.7 =
 * Added Beaver Builder 2.6 to supported versions

--- a/tests/Jobs/UploadJobTest.php
+++ b/tests/Jobs/UploadJobTest.php
@@ -60,7 +60,7 @@ class UploadJobTest extends TestCase
 
         $submissionManager = $this->createMock(SubmissionManager::class);
 
-        $submissionManager->method('findSubmissionsForUploadJob')->willReturn([]);
+        $submissionManager->method('findSubmissionForUploadJob')->willReturn(null);
         $submissionManager->method('find')->willReturn([
             $submission
         ]);
@@ -102,7 +102,7 @@ class UploadJobTest extends TestCase
         $submission = new SubmissionEntity();
 
         $submissionManager = $this->createMock(SubmissionManager::class);
-        $submissionManager->method('findSubmissionsForUploadJob')->willReturn([]);
+        $submissionManager->method('findSubmissionForUploadJob')->willReturn(null);
         $submissionManager->method('find')->willReturn([
             $submission
         ]);
@@ -115,5 +115,17 @@ class UploadJobTest extends TestCase
         $x->run();
 
         $this->assertEquals('', $submission->getBatchUid());
+    }
+
+    public function testSubmissionUploadsProcessed(): void
+    {
+        $submissionManager = $this->createMock(SubmissionManager::class);
+        $submissionManager->expects($this->exactly(2))->method('findSubmissionForUploadJob')
+            ->willReturnOnConsecutiveCalls($this->createMock(SubmissionEntity::class), null);
+
+        $settingsManager = $this->createMock(SettingsManager::class);
+        $settingsManager->method('getActiveProfiles')->willReturn([$this->createMock(ConfigurationProfileEntity::class)]);
+
+        $this->getWorkerMock($submissionManager, $this->createMock(ApiWrapperInterface::class), $settingsManager)->run();
     }
 }

--- a/tests/Smartling/Submissions/SubmissionManagerTest.php
+++ b/tests/Smartling/Submissions/SubmissionManagerTest.php
@@ -132,7 +132,7 @@ class SubmissionManagerTest extends TestCase
         $x->method('getDbal')->willReturn($db);
         $x->expects($this->once())->method('fetchData')->with("SELECT `id`, `source_title`, `source_blog_id`, `source_content_hash`, `content_type`, `source_id`, `file_uri`, `target_locale`, `target_blog_id`, `target_id`, `submitter`, `submission_date`, `applied_date`, `approved_string_count`, `completed_string_count`, `excluded_string_count`, `total_string_count`, `word_count`, `status`, `is_locked`, `is_cloned`, `last_modified`, `outdated`, `last_error`, `batch_uid`, `locked_fields`, `created_at` FROM `wp_smartling_submissions` WHERE ( `status` = 'New' AND `is_locked` = '0' AND `batch_uid` <> '' ) LIMIT 0,1")->willReturn([]);
 
-        $x->findSubmissionsForUploadJob();
+        $this->assertNull($x->findSubmissionForUploadJob());
     }
 
     public function testStoreEmptyEntity()


### PR DESCRIPTION
There is logging in JobAbstract, but it would help to fail submissions, so the user wouldn't need to purge the queue manually. Also, a failure reason would persist in submission.