### PR TITLE
refactor ContentRelationDiscoveryService (WP-786)

### DIFF
--- a/inc/Smartling/Services/ContentRelationsDiscoveryService.php
+++ b/inc/Smartling/Services/ContentRelationsDiscoveryService.php
@@ -545,7 +545,7 @@ class ContentRelationsDiscoveryService
                 if ($processor instanceof MetaFieldProcessorAbstract && 0 !== (int)$fValue) {
                     $shortProcessorName = ArrayHelper::last(explode('\\', get_class($processor)));
 
-                    $detectedReferences[$shortProcessorName][] = (int)$fValue; // TODO uncomment fix, remove following line
+                    $detectedReferences[$shortProcessorName][] = (int)$fValue;
                 } else {
                     $detectedReferences['attachment'] = array_merge($detectedReferences['attachment'],
                         $this->absoluteLinkedAttachmentCoreHelper->getImagesIdsFromString($fValue, $curBlogId));

--- a/inc/Smartling/Services/ContentRelationsDiscoveryService.php
+++ b/inc/Smartling/Services/ContentRelationsDiscoveryService.php
@@ -253,7 +253,7 @@ class ContentRelationsDiscoveryService
                 $relatedIds[$contentType] = array_unique($contentIds);
             }
         } catch (\Exception $e) {
-            $this->getLogger()->error('Failed to build related ids array for audit log');
+            $this->getLogger()->error('Failed to build related ids array for audit log: ' . $e->getMessage());
         }
         try {
             $this->apiWrapper->createAuditLogRecord($profile, CreateRecordParameters::ACTION_TYPE_UPLOAD, $request->getDescription(), [
@@ -263,7 +263,7 @@ class ContentRelationsDiscoveryService
                 'targetBlogIds' => $request->getTargetBlogIds(),
             ], $jobInfo, $job->isAuthorize());
         } catch (\Exception $e) {
-            $this->getLogger()->error(sprintf('Failed to create audit log record actionType=%s, requestDescription="%s", sourceId=%d, sourceBlogId=%d', CreateRecordParameters::ACTION_TYPE_UPLOAD, $request->getDescription(), $request->getContentId(), $curBlogId));
+            $this->getLogger()->error(sprintf('Failed to create audit log record actionType=%s, requestDescription="%s", sourceId=%d, sourceBlogId=%d, errorMessage="%s"', CreateRecordParameters::ACTION_TYPE_UPLOAD, $request->getDescription(), $request->getContentId(), $curBlogId, $e->getMessage()));
         }
 
         if ($request->isBulk()) {
@@ -368,12 +368,11 @@ class ContentRelationsDiscoveryService
     private array $shortcodeFields = [];
 
     /**
-     * @param mixed $attributes
      * @see do_shortcode_tag(), shortcode_parse_atts() attributes might be an array, or an empty string
      * @see extractFieldsFromShortcodes();
      * @noinspection PhpUnused
      */
-    public function shortcodeHandler($attributes, string $content, string $shortcodeName): void
+    public function shortcodeHandler(mixed $attributes, string $content, string $shortcodeName): void
     {
         if (!is_array($attributes)) {
             return;
@@ -449,6 +448,7 @@ class ContentRelationsDiscoveryService
 
     /**
      * @return int[]
+     * @noinspection JsonEncodingApiUsageInspection
      */
     private function addPostContentReferences(array $array, GutenbergBlock $block): array
     {
@@ -469,6 +469,7 @@ class ContentRelationsDiscoveryService
 
     /**
      * @param int[] $targetBlogIds
+     * @noinspection JsonEncodingApiUsageInspection
      */
     public function getRelations(string $contentType, int $id, array $targetBlogIds): DetectedRelations
     {
@@ -544,24 +545,19 @@ class ContentRelationsDiscoveryService
                 if ($processor instanceof MetaFieldProcessorAbstract && 0 !== (int)$fValue) {
                     $shortProcessorName = ArrayHelper::last(explode('\\', get_class($processor)));
 
-                    $detectedReferences[$shortProcessorName][$fValue][] = $fName;
+                    $detectedReferences[$shortProcessorName][] = (int)$fValue; // TODO uncomment fix, remove following line
                 } else {
                     $detectedReferences['attachment'] = array_merge($detectedReferences['attachment'],
                         $this->absoluteLinkedAttachmentCoreHelper->getImagesIdsFromString($fValue, $curBlogId));
                     $detectedReferences['attachment'] = array_unique($detectedReferences['attachment']);
                 }
             } catch (Exception $e) {
-                $this
-                    ->getLogger()
-                    ->warning(
-                        vsprintf(
-                            'failed searching for processor for field \'%s\'=\'%s\'',
-                            [
-                                $fName,
-                                $fValue,
-                            ]
-                        )
-                    );
+                $this->getLogger()->warning(sprintf(
+                    'Failed searching for processor for fieldName="%s", fieldValue="%s", errorMessage="%s"',
+                    $fName,
+                    $fValue,
+                    $e->getMessage(),
+                ));
             }
         }
 
@@ -619,11 +615,12 @@ class ContentRelationsDiscoveryService
         }
 
         if (isset($references[self::POST_BASED_PROCESSOR])) {
-            foreach ($references[self::POST_BASED_PROCESSOR] as $key => $value) {
-                $postId = is_int($value) ? $value : $key;
+            foreach ($references[self::POST_BASED_PROCESSOR] as $postId) {
                 $postType = $this->wordpressProxy->get_post_type($postId);
                 if ($postType !== false) {
                     $result[$postType][] = $postId;
+                } else {
+                    $this->getLogger()->warning("WordPress returned no post exist for detected reference postId=$postId");
                 }
             }
         }
@@ -738,7 +735,7 @@ class ContentRelationsDiscoveryService
             try {
                 $replacer = $this->replacerFactory->getReplacer($rule->getReplacerId());
                 $this->getLogger()->debug("Got replacerId={$rule->getReplacerId()}");
-            } catch (EntityNotFoundException $e) {
+            } catch (EntityNotFoundException) {
                 continue;
             }
             $value = $this->gutenbergBlockHelper->getValue($block, $rule);

--- a/tests/Services/ContentRelationDiscoveryServiceTest.php
+++ b/tests/Services/ContentRelationDiscoveryServiceTest.php
@@ -730,43 +730,7 @@ namespace Smartling\Tests\Services {
                 ]
             ], $relations->getOriginalReferences());
         }
-        public function testNormalizeReferences()
-        {
-            $wpProxy = $this->createMock(WordpressFunctionProxyHelper::class);
-            $wpProxy->method('get_post_type')->willReturnMap([
-                [9224, ContentTypeHelper::CONTENT_TYPE_POST],
-                [10899, ContentTypeHelper::POST_TYPE_ATTACHMENT],
-                [10902, ContentTypeHelper::POST_TYPE_ATTACHMENT],
-                [10903, ContentTypeHelper::POST_TYPE_ATTACHMENT],
-                [11292, ContentTypeHelper::CONTENT_TYPE_POST],
-            ]);
-            $x = $this->getContentRelationDiscoveryService(wpProxy: $wpProxy);
-            $this->assertEquals([
-                'attachment' => [11290, 10903, 10902, 10899],
-                ContentTypeHelper::CONTENT_TYPE_POST => [9224, 11292],
-            ], $x->normalizeReferences(
-                [
-                    ContentTypeHelper::POST_TYPE_ATTACHMENT => [],
-                    'CloneValueFieldProcessor' => [
-                        '11298' => ['entity/post_name'],
-                    ],
-                    'PostBasedProcessor' => [
-                        '9224' => ['entity/post_parent'],
-                        '9225' => 10903,
-                        '9226' => 10902,
-                        '9227' => 10899,
-                        '9228' => 11292,
-                    ],
-                    'MediaBasedProcessor' => [
-                        '11290' => ['meta/_thumbnail_id'],
-                    ],
-                    'SkipFieldProcessor' => [
-                        '-1' => ['meta/stage_key'],
-                    ],
-                    'taxonomies' => [],
-                ]
-            ));
-        }
+
         /**
          * @return MockObject|ContentRelationsDiscoveryService
          */

--- a/tests/Services/ContentRelationDiscoveryServiceTest.php
+++ b/tests/Services/ContentRelationDiscoveryServiceTest.php
@@ -37,6 +37,7 @@ namespace Smartling\Tests\Services {
     use Smartling\Helpers\CustomMenuContentTypeHelper;
     use Smartling\Helpers\FieldsFilterHelper;
     use Smartling\Helpers\GutenbergBlockHelper;
+    use Smartling\Helpers\GutenbergReplacementRule;
     use Smartling\Helpers\MetaFieldProcessor\BulkProcessors\PostBasedProcessor;
     use Smartling\Helpers\MetaFieldProcessor\DefaultMetaFieldProcessor;
     use Smartling\Helpers\MetaFieldProcessor\MetaFieldProcessorManager;
@@ -53,6 +54,7 @@ namespace Smartling\Tests\Services {
     use Smartling\Models\UserCloneRequest;
     use Smartling\Models\UserTranslationRequest;
     use Smartling\Processors\ContentEntitiesIOFactory;
+    use Smartling\Replacers\ContentIdReplacer;
     use Smartling\Replacers\ReplacerFactory;
     use Smartling\Services\ContentRelationsDiscoveryService;
     use Smartling\Services\ContentRelationsHandler;
@@ -656,6 +658,78 @@ namespace Smartling\Tests\Services {
             ], [], '', [])));
         }
 
+        public function testGetRelations()
+        {
+            $contentType = 'post';
+            $postParentId = 9024;
+            $relatedPostId = 13;
+            $fieldsFilterHelper = $this->createPartialMock(FieldsFilterHelper::class, []);
+
+            $mapper = $this->createMock(EntityAbstract::class);
+            $mapper->method('get')->willReturn($mapper);
+            $mapper->method('toArray')->willReturn([
+                'post_content' => "<!-- wp:test {\"relatedContent\":$relatedPostId} /-->",
+                'post_parent' => $postParentId,
+            ]);
+            $mapper->method('getMetadata')->willReturn([]);
+
+            $metaFieldProcessorManager = $this->createMock(MetaFieldProcessorManager::class);
+            $metaFieldProcessorManager->method('getProcessor')->willReturnCallback(function ($field) {
+                if ($field === 'entity/post_parent') {
+                    return $this->getMockBuilder(PostBasedProcessor::class)
+                        ->disableOriginalConstructor()
+                        ->setMockClassName(ContentRelationsDiscoveryService::POST_BASED_PROCESSOR)
+                        ->getMock();
+                }
+
+                return $this->createMock(DefaultMetaFieldProcessor::class);
+            });
+
+            $ioFactory = $this->createMock(ContentEntitiesIOFactory::class);
+            $ioFactory->method('getMapper')->willReturn($mapper);
+
+            $siteHelper = $this->createMock(SiteHelper::class);
+            $siteHelper->method('getCurrentBlogId')->willReturn(1);
+
+            $contentHelper = $this->createMock(ContentHelper::class);
+            $contentHelper->method('checkEntityExists')->willReturn(true);
+            $contentHelper->method('getIoFactory')->willReturn($ioFactory);
+            $contentHelper->method('getSiteHelper')->willReturn($siteHelper);
+
+            $gutenbergBlockHelper = $this->createMock(GutenbergBlockHelper::class);
+            $gutenbergBlockHelper->method('parseBlocks')->willReturn([
+                new GutenbergBlock('test', ['relatedContent' => $relatedPostId], [], '', []),
+            ]);
+            $gutenbergBlockHelper->method('getValue')->willReturn($relatedPostId);
+
+            $mediaAttachmentRulesManager = $this->createMock(MediaAttachmentRulesManager::class);
+            $mediaAttachmentRulesManager->method('getGutenbergReplacementRules')->willReturn([
+                new GutenbergReplacementRule('test', '$.relatedContent', ReplacerFactory::REPLACER_RELATED),
+            ]);
+
+            $replacerFactory = $this->createMock(ReplacerFactory::class);
+            $replacerFactory->method('getReplacer')->willReturn($this->createMock(ContentIdReplacer::class));
+
+            $wordpressProxy = $this->createMock(WordpressFunctionProxyHelper::class);
+            $wordpressProxy->method('get_post_type')->willReturn($contentType);
+
+            $x = $this->getContentRelationDiscoveryService(
+                contentHelper: $contentHelper,
+                metaFieldProcessorManager: $metaFieldProcessorManager,
+                fieldsFilterHelper: $fieldsFilterHelper,
+                wpProxy: $wordpressProxy,
+                gutenbergBlockHelper: $gutenbergBlockHelper,
+                mediaAttachmentRulesManager: $mediaAttachmentRulesManager,
+                replacerFactory: $replacerFactory,
+            );
+            $relations = $x->getRelations($contentType, 1, [2]);
+            $this->assertEquals([
+                $contentType => [
+                    $postParentId,
+                    13,
+                ]
+            ], $relations->getOriginalReferences());
+        }
         public function testNormalizeReferences()
         {
             $wpProxy = $this->createMock(WordpressFunctionProxyHelper::class);
@@ -706,7 +780,10 @@ namespace Smartling\Tests\Services {
             FieldsFilterHelper $fieldsFilterHelper = null,
             AcfDynamicSupport $acfDynamicSupport = null,
             WordpressFunctionProxyHelper $wpProxy = null,
-            ContentTypeManager $contentTypeManager = null
+            ContentTypeManager $contentTypeManager = null,
+            GutenbergBlockHelper $gutenbergBlockHelper = null,
+            MediaAttachmentRulesManager $mediaAttachmentRulesManager = null,
+            ReplacerFactory $replacerFactory = null,
         )
         {
             if ($apiWrapper === null) {
@@ -721,24 +798,34 @@ namespace Smartling\Tests\Services {
             if ($contentTypeManager === null) {
                 $contentTypeManager = $this->createMock(ContentTypeManager::class);
             }
+            if ($fieldsFilterHelper === null) {
+                $fieldsFilterHelper = $this->createMock(FieldsFilterHelper::class);
+            }
+            if ($gutenbergBlockHelper === null) {
+                $gutenbergBlockHelper = $this->createMock(GutenbergBlockHelper::class);
+            }
+            if ($mediaAttachmentRulesManager === null) {
+                $mediaAttachmentRulesManager = $this->createMock(MediaAttachmentRulesManager::class);
+            }
             if ($metaFieldProcessorManager === null) {
                 $metaFieldProcessorManager = $this->createMock(MetaFieldProcessorManager::class);
             }
-            if ($fieldsFilterHelper === null) {
-                $fieldsFilterHelper = $this->createMock(FieldsFilterHelper::class);
+            if ($replacerFactory === null) {
+                $replacerFactory = $this->createMock(ReplacerFactory::class);
             }
             if ($settingsManager === null) {
                 $settingsManager = $this->createMock(SettingsManager::class);
             }
-            if ($submissionManager === null) {
-                $submissionManager = $this->createMock(SubmissionManager::class);
-            }
             if ($submissionFactory === null) {
                 $submissionFactory = $this->createMock(SubmissionFactory::class);
+            }
+            if ($submissionManager === null) {
+                $submissionManager = $this->createMock(SubmissionManager::class);
             }
             if ($wpProxy === null) {
                 $wpProxy = $this->createMock(WordpressFunctionProxyHelper::class);
             }
+
             return $this->getMockBuilder(ContentRelationsDiscoveryService::class)->setConstructorArgs([
                 $acfDynamicSupport,
                 $contentHelper,
@@ -748,12 +835,12 @@ namespace Smartling\Tests\Services {
                 $this->createMock(LocalizationPluginProxyInterface::class),
                 $this->createMock(AbsoluteLinkedAttachmentCoreHelper::class),
                 $this->createMock(ShortcodeHelper::class),
-                $this->createMock(GutenbergBlockHelper::class),
+                $gutenbergBlockHelper,
                 $submissionFactory,
                 $submissionManager,
                 $apiWrapper,
-                $this->createMock(MediaAttachmentRulesManager::class),
-                $this->createMock(ReplacerFactory::class),
+                $mediaAttachmentRulesManager,
+                $replacerFactory,
                 $settingsManager,
                 $this->createMock(CustomMenuContentTypeHelper::class),
                 $this->createMock(ExternalContentManager::class),


### PR DESCRIPTION
there was no usage of field names, yet they were messing with the later discovered ids of post-based content