### PR TITLE
add Gravity Forms support (WP-782)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "",
   "type": "wordpress-plugin",
   "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "531739b98c7f83a6eac997b64fb46d15",
+    "content-hash": "64179cbbf45af132da43d1891df7d02b",
     "packages": [
         {
             "name": "galbar/jsonpath",
@@ -826,16 +826,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
                 "shasum": ""
             },
             "require": {
@@ -850,7 +850,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -888,7 +888,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -904,20 +904,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "59a8d271f00dd0e4c2e518104cc7963f655a1aa8"
+                "reference": "639084e360537a19f9ee352433b84ce831f3d2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/59a8d271f00dd0e4c2e518104cc7963f655a1aa8",
-                "reference": "59a8d271f00dd0e4c2e518104cc7963f655a1aa8",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da",
+                "reference": "639084e360537a19f9ee352433b84ce831f3d2da",
                 "shasum": ""
             },
             "require": {
@@ -931,7 +931,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -975,7 +975,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -991,20 +991,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
+                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
-                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
                 "shasum": ""
             },
             "require": {
@@ -1016,7 +1016,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1059,7 +1059,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -1075,20 +1075,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2"
+                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/bf44a9fd41feaac72b074de600314a93e2ae78e2",
-                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97",
+                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97",
                 "shasum": ""
             },
             "require": {
@@ -1097,7 +1097,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1135,7 +1135,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -1151,7 +1151,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1212,16 +1212,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/vsolovei-smartling/retry.git",
-                "reference": "b15389ebb7c71c7e9057895d375536cc97844b1f"
+                "reference": "d14b934950154f58152daa295cc4062dbcf720d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vsolovei-smartling/retry/zipball/b15389ebb7c71c7e9057895d375536cc97844b1f",
-                "reference": "b15389ebb7c71c7e9057895d375536cc97844b1f",
+                "url": "https://api.github.com/repos/vsolovei-smartling/retry/zipball/d14b934950154f58152daa295cc4062dbcf720d6",
+                "reference": "d14b934950154f58152daa295cc4062dbcf720d6",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^3.1"
@@ -1248,7 +1248,7 @@
             "support": {
                 "source": "https://github.com/vsolovei-smartling/retry/tree/2.0.1"
             },
-            "time": "2022-09-20T09:18:59+00:00"
+            "time": "2022-11-21T11:14:42+00:00"
         }
     ],
     "packages-dev": [
@@ -1383,16 +1383,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.1",
+            "version": "v4.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900"
+                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
                 "shasum": ""
             },
             "require": {
@@ -1433,9 +1433,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
             },
-            "time": "2022-09-04T07:30:47+00:00"
+            "time": "2022-11-12T15:38:23+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1550,16 +1550,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.17",
+            "version": "9.2.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8"
+                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa94dc41e8661fe90c7316849907cba3007b10d8",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
+                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
                 "shasum": ""
             },
             "require": {
@@ -1615,7 +1615,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.17"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.21"
             },
             "funding": [
                 {
@@ -1623,7 +1623,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-30T12:24:04+00:00"
+            "time": "2022-12-14T13:26:54+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1868,16 +1868,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.24",
+            "version": "9.5.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5"
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
                 "shasum": ""
             },
             "require": {
@@ -1899,14 +1899,14 @@
                 "phpunit/php-timer": "^5.0.2",
                 "sebastian/cli-parser": "^1.0.1",
                 "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.5",
+                "sebastian/comparator": "^4.0.8",
                 "sebastian/diff": "^4.0.3",
                 "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.3",
+                "sebastian/exporter": "^4.0.5",
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.1",
+                "sebastian/type": "^3.2",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -1950,7 +1950,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.27"
             },
             "funding": [
                 {
@@ -1960,9 +1960,13 @@
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-08-30T07:42:16+00:00"
+            "time": "2022-12-09T07:31:23+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2985,7 +2989,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1",
+        "php": ">=8.0",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-json": "*"

--- a/inc/Smartling/Base/SmartlingCore.php
+++ b/inc/Smartling/Base/SmartlingCore.php
@@ -5,6 +5,7 @@ namespace Smartling\Base;
 use Exception;
 use Smartling\ContentTypes\ContentTypeNavigationMenu;
 use Smartling\ContentTypes\ExternalContentManager;
+use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
 use Smartling\Exception\BlogNotFoundException;
 use Smartling\Exception\SmartlingDbException;
 use Smartling\Exception\SmartlingExceptionAbstract;
@@ -70,7 +71,7 @@ class SmartlingCore extends SmartlingCoreAbstract
             $submission->getId(),
         ]));
         $originalEntity = $this->getContentHelper()->readSourceContent($submission);
-        $relatedContentTypes = $originalEntity->getRelatedTypes();
+        $relatedContentTypes = $originalEntity instanceof EntityAbstract ? $originalEntity->getRelatedTypes() : [];
         $accumulator = [
             'category' => [],
             'post_tag' => [],

--- a/inc/Smartling/Base/SmartlingCore.php
+++ b/inc/Smartling/Base/SmartlingCore.php
@@ -71,7 +71,7 @@ class SmartlingCore extends SmartlingCoreAbstract
             $submission->getId(),
         ]));
         $originalEntity = $this->getContentHelper()->readSourceContent($submission);
-        $relatedContentTypes = $originalEntity instanceof EntityAbstract ? $originalEntity->getRelatedTypes() : [];
+        $relatedContentTypes = $originalEntity->getRelatedTypes();
         $accumulator = [
             'category' => [],
             'post_tag' => [],

--- a/inc/Smartling/Base/SmartlingCoreAbstract.php
+++ b/inc/Smartling/Base/SmartlingCoreAbstract.php
@@ -252,10 +252,7 @@ abstract class SmartlingCoreAbstract
         $this->queue = $queue;
     }
 
-    /**
-     * @return ContentHelper
-     */
-    public function getContentHelper()
+    public function getContentHelper(): ContentHelper
     {
         return $this->contentHelper;
     }

--- a/inc/Smartling/Base/SmartlingCoreTrait.php
+++ b/inc/Smartling/Base/SmartlingCoreTrait.php
@@ -2,6 +2,8 @@
 
 namespace Smartling\Base;
 
+use Smartling\DbAl\WordpressContentEntities\EntityWithPostStatus;
+use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
 use Smartling\Helpers\ArrayHelper;
 use Smartling\Helpers\ContentSerializationHelper;
 use Smartling\Submissions\SubmissionEntity;
@@ -58,7 +60,9 @@ trait SmartlingCoreTrait
 
         if (false === $update) {
             $targetContent = clone $originalContent;
-            $targetContent->cleanFields();
+            if ($targetContent instanceof EntityAbstract) {
+                $targetContent->cleanFields();
+            }
         } else {
             $targetContent = $this->getContentHelper()->readTargetContent($submission);
         }
@@ -73,6 +77,7 @@ trait SmartlingCoreTrait
         unset ($hardFilteredOriginalData['entity']['ID'], $hardFilteredOriginalData['entity']['term_id'], $hardFilteredOriginalData['entity']['id']);
 
         if (array_key_exists('entity', $hardFilteredOriginalData) &&
+            $targetContent instanceof EntityAbstract &&
             ArrayHelper::notEmpty($hardFilteredOriginalData['entity'])
         ) {
             $_entity = &$hardFilteredOriginalData['entity'];
@@ -85,12 +90,12 @@ trait SmartlingCoreTrait
             }
         }
 
-        if (false === $forceClone) {
+        if (false === $forceClone && $targetContent instanceof EntityWithPostStatus) {
             $targetContent->translationDrafted();
         }
 
         $targetContent = $this->getContentHelper()->writeTargetContent($submission, $targetContent);
-        $submission->setTargetId($targetContent->getPK());
+        $submission->setTargetId($targetContent->getId());
         $submission = $this->getSubmissionManager()->storeEntity($submission);
         $this->externalContentManager->setExternalContent($unfilteredSourceData, $this->externalContentManager->getExternalContent([], $submission, true), $submission);
 
@@ -102,7 +107,7 @@ trait SmartlingCoreTrait
                         $submission->getId(),
                         $submission->getTargetLocale(),
                         $submission->getTargetBlogId(),
-                        $targetContent->getPK(),
+                        $targetContent->getId(),
                     ]
                 )
             );
@@ -123,7 +128,7 @@ trait SmartlingCoreTrait
         }
 
         if (false === $update) {
-            $submission->setTargetId($targetContent->getPK());
+            $submission->setTargetId($targetContent->getId());
             $submission = $this->getSubmissionManager()->storeEntity($submission);
         }
 

--- a/inc/Smartling/Base/SmartlingCoreTrait.php
+++ b/inc/Smartling/Base/SmartlingCoreTrait.php
@@ -56,16 +56,9 @@ trait SmartlingCoreTrait
             )
         );
 
-        $originalContent = $this->getContentHelper()->readSourceContent($submission);
-
-        if (false === $update) {
-            $targetContent = clone $originalContent;
-            if ($targetContent instanceof EntityAbstract) {
-                $targetContent->cleanFields();
-            }
-        } else {
-            $targetContent = $this->getContentHelper()->readTargetContent($submission);
-        }
+        $targetContent = $update ?
+            $this->getContentHelper()->readTargetContent($submission) :
+            $this->getContentHelper()->readSourceContent($submission)->forInsert();
 
         $this->prepareFieldProcessorValues($submission);
         $unfilteredSourceData = $this->readSourceContentWithMetadataAsArray($submission);

--- a/inc/Smartling/Base/SmartlingCoreUploadTrait.php
+++ b/inc/Smartling/Base/SmartlingCoreUploadTrait.php
@@ -5,6 +5,8 @@ namespace Smartling\Base;
 use Exception;
 use JetBrains\PhpStorm\ArrayShape;
 use Smartling\ContentTypes\ContentTypeNavigationMenuItem;
+use Smartling\DbAl\WordpressContentEntities\EntityInterface;
+use Smartling\DbAl\WordpressContentEntities\EntityWithPostStatus;
 use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
 use Smartling\Exception\BlogNotFoundException;
 use Smartling\Exception\EntityNotFoundException;
@@ -45,16 +47,10 @@ trait SmartlingCoreUploadTrait
     #[ArrayShape(['entity' => [], 'meta' => []])]
     private function readSourceContentWithMetadataAsArray(SubmissionEntity $submission): array
     {
-        $source = [
+        return [
             'entity' => $this->getContentHelper()->readSourceContent($submission)->toArray(),
-            'meta'   => $this->getContentHelper()->readSourceMetadata($submission),
+            'meta' => $this->getContentHelper()->readSourceMetadata($submission),
         ];
-
-        if (!is_array($source['meta'])) {
-            $source['meta'] = [];
-        }
-
-        return $source;
     }
 
     protected function getFunctionProxyHelper(): WordpressFunctionProxyHelper
@@ -254,7 +250,11 @@ trait SmartlingCoreUploadTrait
                 $this->getLogger()->critical('Translation is not array after applying filter ' . ExportedAPI::FILTER_BEFORE_TRANSLATION_APPLIED . '. This is most likely due to an error outside of the plugins code.');
             }
             $translation = $this->externalContentManager->setExternalContent($original, $translation, $submission);
-            $this->setValues($targetContent, $translation['entity'] ?? []);
+            if ($targetContent instanceof EntityAbstract) {
+                $this->setValues($targetContent, $translation['entity'] ?? []);
+            } else {
+                $targetContent = $targetContent->fromArray($translation['entity']);
+            }
             $configurationProfile = $this->getSettingsManager()
                 ->getSingleSettingsProfile($submission->getSourceBlogId());
 
@@ -277,7 +277,7 @@ trait SmartlingCoreUploadTrait
                 );
                 $submission->setStatus(SubmissionEntity::SUBMISSION_STATUS_COMPLETED);
                 $translationPublishingMode = $configurationProfile->getTranslationPublishingMode();
-                if (ConfigurationProfileEntity::TRANSLATION_PUBLISHING_MODE_NO_CHANGE !== $translationPublishingMode) {
+                if (ConfigurationProfileEntity::TRANSLATION_PUBLISHING_MODE_NO_CHANGE !== $translationPublishingMode && $targetContent instanceof EntityWithPostStatus) {
                     $this->getLogger()->debug(
                         vsprintf(
                             'Submission id=%s (blog=%s, item=%s, content-type=%s) setting status %s for translation',
@@ -787,7 +787,7 @@ trait SmartlingCoreUploadTrait
         return $this->getFieldsFilter()->removeFields($fields, $configurationProfile->getFilterSkipArray(), $configurationProfile->getFilterFieldNameRegExp());
     }
 
-    private function processPostContentBlocks(EntityAbstract $targetContent, array $original, array $translation, SubmissionEntity $submission, PostContentHelper $postContentHelper, array $lockedEntityFields): array
+    private function processPostContentBlocks(EntityInterface $targetContent, array $original, array $translation, SubmissionEntity $submission, PostContentHelper $postContentHelper, array $lockedEntityFields): array
     {
         if (array_key_exists('entity', $translation) && ArrayHelper::notEmpty($translation['entity'])) {
             $targetContentArray = $targetContent->toArray();

--- a/inc/Smartling/Base/SmartlingCoreUploadTrait.php
+++ b/inc/Smartling/Base/SmartlingCoreUploadTrait.php
@@ -5,7 +5,7 @@ namespace Smartling\Base;
 use Exception;
 use JetBrains\PhpStorm\ArrayShape;
 use Smartling\ContentTypes\ContentTypeNavigationMenuItem;
-use Smartling\DbAl\WordpressContentEntities\EntityInterface;
+use Smartling\DbAl\WordpressContentEntities\Entity;
 use Smartling\DbAl\WordpressContentEntities\EntityWithPostStatus;
 use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
 use Smartling\Exception\BlogNotFoundException;
@@ -787,7 +787,7 @@ trait SmartlingCoreUploadTrait
         return $this->getFieldsFilter()->removeFields($fields, $configurationProfile->getFilterSkipArray(), $configurationProfile->getFilterFieldNameRegExp());
     }
 
-    private function processPostContentBlocks(EntityInterface $targetContent, array $original, array $translation, SubmissionEntity $submission, PostContentHelper $postContentHelper, array $lockedEntityFields): array
+    private function processPostContentBlocks(Entity $targetContent, array $original, array $translation, SubmissionEntity $submission, PostContentHelper $postContentHelper, array $lockedEntityFields): array
     {
         if (array_key_exists('entity', $translation) && ArrayHelper::notEmpty($translation['entity'])) {
             $targetContentArray = $targetContent->toArray();

--- a/inc/Smartling/ContentTypes/ConfigParsers/ConfigParserAbstract.php
+++ b/inc/Smartling/ContentTypes/ConfigParsers/ConfigParserAbstract.php
@@ -120,12 +120,9 @@ abstract class ConfigParserAbstract implements ConfigParserInterface
         $this->widgetMessage = $widgetMessage;
     }
 
-    /**
-     * @return array
-     */
-    public function getVisibility()
+    public function getVisibility(string $page): bool
     {
-        return $this->visibility;
+        return array_key_exists($page, $this->visibility) ? $this->visibility[$page] : false;
     }
 
     /**
@@ -161,5 +158,40 @@ abstract class ConfigParserAbstract implements ConfigParserInterface
     public function hasWidget()
     {
         return $this->isValid() && true === $this->isWidgetVisible();
+    }
+
+    protected function hydrate($config): void
+    {
+        if (is_string($config)) {
+            $config = ['identifier' => $config];
+        }
+
+        $label = array_key_exists('label', $config) ? $config['label'] : '';
+
+        $typeTemplate = [
+            'identifier' => 'unknown',
+            'label' => '',
+            'widget' => [
+                'visible' => false,
+                'message' => vsprintf('No original %s found', [$label]),
+            ],
+            'visibility' => [
+                'submissionBoard' => true,
+                'bulkSubmit' => true,
+            ],
+        ];
+
+        $config = array_replace_recursive($typeTemplate, $config);
+
+        if ('unknown' !== $config['identifier']) {
+            $this->setIdentifier($config['identifier']);
+        }
+        if (!StringHelper::isNullOrEmpty($config['label'])) {
+            $this->setLabel($config['label']);
+        }
+        $this->setWidgetVisible($config['widget']['visible']);
+        $this->setWidgetMessage($config['widget']['message']);
+
+        $this->setVisibility($config['visibility']);
     }
 }

--- a/inc/Smartling/ContentTypes/ConfigParsers/ConfigParserInterface.php
+++ b/inc/Smartling/ContentTypes/ConfigParsers/ConfigParserInterface.php
@@ -2,17 +2,9 @@
 
 namespace Smartling\ContentTypes\ConfigParsers;
 
-/**
- * Interface ConfigParserInterface
- * @package Smartling\ContentTypes\ConfigParsers
- */
 interface ConfigParserInterface
 {
-    /**
-     * Parses given config
-     * @return void
-     */
-    public function parse();
+    public function parse(): void;
 
     /**
      * returns true if config is valid
@@ -26,8 +18,5 @@ interface ConfigParserInterface
      */
     public function hasWidget();
 
-    /**
-     * @return array;
-     */
-    public function getVisibility();
+    public function getVisibility(string $page): bool;
 }

--- a/inc/Smartling/ContentTypes/ConfigParsers/PostTypeConfigParser.php
+++ b/inc/Smartling/ContentTypes/ConfigParsers/PostTypeConfigParser.php
@@ -2,57 +2,13 @@
 
 namespace Smartling\ContentTypes\ConfigParsers;
 
-use Smartling\Helpers\StringHelper;
-
-/**
- * Class PostTypeConfigParser
- * @package Smartling\ContentTypes\ConfigParsers
- */
 class PostTypeConfigParser extends ConfigParserAbstract
 {
-    private function validateType($config)
-    {
-        if (is_string($config)) {
-            $config = ['identifier' => $config];
-        }
-
-        $label = array_key_exists('label', $config) ? $config['label'] : '';
-
-        $typeTemplate = [
-            'identifier' => 'unknown',
-            'label'      => '',
-            'widget'     => [
-                'visible' => false,
-                'message' => vsprintf('No original %s found', [$label]),
-            ],
-            'visibility' => [
-                'submissionBoard' => true,
-                'bulkSubmit'      => true,
-            ],
-        ];
-
-        $config = array_replace_recursive($typeTemplate, $config);
-
-        if ('unknown' !== $config['identifier']) {
-            $this->setIdentifier($config['identifier']);
-        }
-        if (!StringHelper::isNullOrEmpty($config['label'])) {
-            $this->setLabel($config['label']);
-        }
-        $this->setWidgetVisible($config['widget']['visible']);
-        $this->setWidgetMessage($config['widget']['message']);
-
-        $this->setVisibility($config['visibility']);
-    }
-
-    /**
-     * @return mixed
-     */
-    public function parse()
+    public function parse(): void
     {
         $rawConfig = $this->getRawConfig();
         if (array_key_exists('type', $rawConfig)) {
-            $this->validateType($rawConfig['type']);
+            $this->hydrate($rawConfig['type']);
         }
     }
 }

--- a/inc/Smartling/ContentTypes/ConfigParsers/TermTypeConfigParser.php
+++ b/inc/Smartling/ContentTypes/ConfigParsers/TermTypeConfigParser.php
@@ -2,57 +2,13 @@
 
 namespace Smartling\ContentTypes\ConfigParsers;
 
-use Smartling\Helpers\StringHelper;
-
-/**
- * Class CustomPostTypeConfigParser
- * @package Smartling\ContentTypes
- */
 class TermTypeConfigParser extends ConfigParserAbstract
 {
-    private function validateType($config)
-    {
-        if (is_string($config)) {
-            $config = ['identifier' => $config];
-        }
-
-        $label = array_key_exists('label', $config) ? $config['label'] : '';
-
-        $typeTemplate = [
-            'identifier' => 'unknown',
-            'label'      => '',
-            'widget'     => [
-                'visible' => false,
-                'message' => vsprintf('No original %s found', [$label]),
-            ],
-            'visibility' => [
-                'submissionBoard' => true,
-                'bulkSubmit'      => true,
-            ],
-        ];
-
-        $config = array_replace_recursive($typeTemplate, $config);
-
-        if ('unknown' !== $config['identifier']) {
-            $this->setIdentifier($config['identifier']);
-        }
-        if (!StringHelper::isNullOrEmpty($config['label'])) {
-            $this->setLabel($config['label']);
-        }
-        $this->setWidgetVisible($config['widget']['visible']);
-        $this->setWidgetMessage($config['widget']['message']);
-
-        $this->setVisibility($config['visibility']);
-    }
-
-    /**
-     * @return mixed
-     */
-    public function parse()
+    public function parse(): void
     {
         $rawConfig = $this->getRawConfig();
         if (array_key_exists('taxonomy', $rawConfig)) {
-            $this->validateType($rawConfig['taxonomy']);
+            $this->hydrate($rawConfig['taxonomy']);
         }
     }
 }

--- a/inc/Smartling/ContentTypes/ContentTypeAbstract.php
+++ b/inc/Smartling/ContentTypes/ContentTypeAbstract.php
@@ -27,7 +27,7 @@ abstract class ContentTypeAbstract implements ContentTypeInterface
         ];
     }
 
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
+    public static function register(ContainerBuilder $di, string $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);

--- a/inc/Smartling/ContentTypes/ContentTypeAbstract.php
+++ b/inc/Smartling/ContentTypes/ContentTypeAbstract.php
@@ -5,7 +5,7 @@ namespace Smartling\ContentTypes;
 use Smartling\Exception\SmartlingConfigException;
 use Smartling\Vendor\Symfony\Component\DependencyInjection\ContainerBuilder;
 
-abstract class ContentTypeAbstract implements ContentTypeInterface
+abstract class ContentTypeAbstract extends UnregisteredContentTypeAbstract
 {
     private ContainerBuilder $containerBuilder;
 
@@ -19,11 +19,6 @@ abstract class ContentTypeAbstract implements ContentTypeInterface
         $this->containerBuilder = $di;
     }
 
-    public function isVisible(string $page): bool
-    {
-        return true;
-    }
-
     public static function register(ContainerBuilder $di, string $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
@@ -32,25 +27,5 @@ abstract class ContentTypeAbstract implements ContentTypeInterface
             throw new SmartlingConfigException(ContentTypeManager::class . ' expected');
         }
         $mgr->addDescriptor($descriptor);
-    }
-
-    public function isTaxonomy(): bool
-    {
-        return false;
-    }
-
-    public function isPost(): bool
-    {
-        return false;
-    }
-
-    public function isVirtual(): bool
-    {
-        return false;
-    }
-
-    public function forceDisplay(): bool
-    {
-        return false;
     }
 }

--- a/inc/Smartling/ContentTypes/ContentTypeAbstract.php
+++ b/inc/Smartling/ContentTypes/ContentTypeAbstract.php
@@ -19,12 +19,9 @@ abstract class ContentTypeAbstract implements ContentTypeInterface
         $this->containerBuilder = $di;
     }
 
-    public function getVisibility(): array
+    public function isVisible(string $page): bool
     {
-        return [
-            'bulkSubmit' => true,
-            'submissionBoard' => true,
-        ];
+        return true;
     }
 
     public static function register(ContainerBuilder $di, string $manager = 'content-type-descriptor-manager'): void

--- a/inc/Smartling/ContentTypes/ContentTypeAbstract.php
+++ b/inc/Smartling/ContentTypes/ContentTypeAbstract.php
@@ -2,85 +2,57 @@
 
 namespace Smartling\ContentTypes;
 
+use Smartling\Exception\SmartlingConfigException;
 use Smartling\Vendor\Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Class ContentTypeAbstract
- * @package Smartling\ContentTypes
- */
 abstract class ContentTypeAbstract implements ContentTypeInterface
 {
-    private $containerBuilder;
+    private ContainerBuilder $containerBuilder;
 
-    /**
-     * @return ContainerBuilder
-     */
-    public function getContainerBuilder()
+    public function getContainerBuilder(): ContainerBuilder
     {
         return $this->containerBuilder;
     }
 
-    /**
-     * @param ContainerBuilder $containerBuilder
-     */
-    public function setContainerBuilder(ContainerBuilder $containerBuilder)
-    {
-        $this->containerBuilder = $containerBuilder;
-    }
-
-    /**
-     * ContentTypeAbstract constructor.
-     *
-     * @param ContainerBuilder $di
-     */
     public function __construct(ContainerBuilder $di)
     {
-        $this->setContainerBuilder($di);
+        $this->containerBuilder = $di;
     }
 
-    /**
-     * @param ContainerBuilder $di
-     * @param string           $manager
-     */
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager')
+    public function getVisibility(): array
+    {
+        return [
+            'bulkSubmit' => true,
+            'submissionBoard' => true,
+        ];
+    }
+
+    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);
-        /**
-         * @var \Smartling\ContentTypes\ContentTypeManager $mgr
-         */
+        if (!$mgr instanceof ContentTypeManager) {
+            throw new SmartlingConfigException(ContentTypeManager::class . ' expected');
+        }
         $mgr->addDescriptor($descriptor);
     }
 
-    /**
-     * @return bool
-     */
-    public function isTaxonomy()
+    public function isTaxonomy(): bool
     {
         return false;
     }
 
-    /**
-     * @return bool
-     */
-    public function isPost()
+    public function isPost(): bool
     {
         return false;
     }
 
-    /**
-     * @return bool
-     */
-    public function isVirtual()
+    public function isVirtual(): bool
     {
         return false;
     }
 
-    /**
-     * Place to filters even if not registered in Wordpress
-     * @return bool
-     */
-    public function forceDisplay()
+    public function forceDisplay(): bool
     {
         return false;
     }

--- a/inc/Smartling/ContentTypes/ContentTypeInterface.php
+++ b/inc/Smartling/ContentTypes/ContentTypeInterface.php
@@ -17,11 +17,7 @@ interface ContentTypeInterface
      */
     public function getLabel(): string;
 
-    #[ArrayShape([
-        'bulkSubmit' => 'bool',
-        'submissionBoard' => 'bool',
-    ])]
-    public function getVisibility(): array;
+    public function isVisible(string $page): bool;
 
     public function isTaxonomy(): bool;
 

--- a/inc/Smartling/ContentTypes/ContentTypeInterface.php
+++ b/inc/Smartling/ContentTypes/ContentTypeInterface.php
@@ -2,7 +2,6 @@
 
 namespace Smartling\ContentTypes;
 
-use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\ExpectedValues;
 
 interface ContentTypeInterface

--- a/inc/Smartling/ContentTypes/ContentTypeInterface.php
+++ b/inc/Smartling/ContentTypes/ContentTypeInterface.php
@@ -2,92 +2,41 @@
 
 namespace Smartling\ContentTypes;
 
-use Smartling\Vendor\Symfony\Component\DependencyInjection\ContainerBuilder;
+use JetBrains\PhpStorm\ArrayShape;
+use JetBrains\PhpStorm\ExpectedValues;
 
-/**
- * Interface ContentTypeInterface
- * @package Smartling\ContentTypes
- */
 interface ContentTypeInterface
 {
     /**
-     * constructor.
-     *
-     * @param ContainerBuilder $di
+     * WordPress slug of content-type, e.g.: post, page, post-tag
      */
-    public function __construct(ContainerBuilder $di);
-
-    /**
-     * @return ContainerBuilder
-     */
-    public function getContainerBuilder();
-
-    /**
-     * @param ContainerBuilder $containerBuilder
-     */
-    public function setContainerBuilder(ContainerBuilder $containerBuilder);
-
-    /**
-     * Wordpress name of content-type, e.g.: post, page, post-tag
-     * @return string
-     */
-    public function getSystemName();
+    public function getSystemName(): string;
 
     /**
      * Display name of content type, e.g.: Post
+     */
+    public function getLabel(): string;
+
+    #[ArrayShape([
+        'bulkSubmit' => 'bool',
+        'submissionBoard' => 'bool',
+    ])]
+    public function getVisibility(): array;
+
+    public function isTaxonomy(): bool;
+
+    public function isPost(): bool;
+
+    public function isVirtual(): bool;
+
+    /**
+     * Display in filters even if not registered in WordPress
+     */
+    public function forceDisplay(): bool;
+
+    /**
      * @return string
      */
-    public function getLabel();
-
-    /**
-     * @return array [
-     *  'submissionBoard'   => true|false,
-     *  'bulkSubmit'        => true|false
-     * ]
-     */
-    public function getVisibility();
-
-    /**
-     * @return bool
-     */
-    public function isTaxonomy();
-
-    /**
-     * @return bool
-     */
-    public function isPost();
-
-    /**
-     * @return bool
-     */
-    public function isVirtual();
-
-    /**
-     * Place to filters even if not registered in Wordpress
-     * @return bool
-     */
-    public function forceDisplay();
-
-    /**
-     * Handler to register IO Wrapper
-     * @return void
-     */
-    public function registerIOWrapper();
-
-    /**
-     * Handler to register Widget (Edit Screen)
-     * @return void
-     */
-    public function registerWidgetHandler();
-
-    /**
-     * @return void
-     */
-    public function registerFilters();
-
-    /**
-     * Base type can be 'post' or 'term' used for Multilingual Press plugin.
-     * @return string
-     */
-    public function getBaseType();
+    #[ExpectedValues(values: ['post', 'taxonomy'])]
+    public function getBaseType(): string;
 }

--- a/inc/Smartling/ContentTypes/ContentTypeManager.php
+++ b/inc/Smartling/ContentTypes/ContentTypeManager.php
@@ -62,7 +62,7 @@ class ContentTypeManager extends SmartlingFactoryAbstract
             if (!$descriptor instanceof ContentTypeInterface) {
                 throw new SmartlingConfigException(ContentTypeInterface::class . ' expected');
             }
-            if (false === $descriptor->getVisibility()['bulkSubmit']) {
+            if (!$descriptor->isVisible('bulkSubmit')) {
                 $output[] = $descriptor->getSystemName();
             }
         }

--- a/inc/Smartling/ContentTypes/ContentTypeManager.php
+++ b/inc/Smartling/ContentTypes/ContentTypeManager.php
@@ -2,58 +2,41 @@
 
 namespace Smartling\ContentTypes;
 
+use Smartling\Exception\SmartlingConfigException;
 use Smartling\Exception\SmartlingInvalidFactoryArgumentException;
 use Smartling\Processors\SmartlingFactoryAbstract;
 
-/**
- * Class ContentTypeManager
- * @package Smartling\ContentTypes
- */
 class ContentTypeManager extends SmartlingFactoryAbstract
 {
+    public const VIRTUAL = 'virtual';
+    private static array $baseTypes = ['post', 'taxonomy', self::VIRTUAL];
 
-    private static $baseTypes = ['post', 'taxonomy', 'virtual'];
-
-    /**
-     * ContentTypeManager constructor.
-     */
-    public function __construct()
+    public function __construct(bool $allowDefault = false, ?object $defaultHandler = null)
     {
-        parent::__construct();
+        parent::__construct($allowDefault, $defaultHandler);
         $this->message = 'Requested descriptor for \'%s\' that doesn\'t exists.';
-        $this->setAllowDefault(false);
     }
 
-    /**
-     * @param ContentTypeInterface $descriptor
-     */
-    public function addDescriptor(ContentTypeInterface $descriptor)
+    public function addDescriptor(ContentTypeInterface $descriptor): void
     {
         $this->registerHandler($descriptor->getSystemName(), $descriptor);
     }
 
-    /**
-     * @param string $systemName
-     *
-     * @return ContentTypeInterface
-     */
-    public function getDescriptorByType($systemName)
+    public function getDescriptorByType(string $systemName): ContentTypeInterface
     {
         return $this->getHandler($systemName);
     }
 
     /**
-     * @param string $baseType
-     *
      * @return ContentTypeInterface[]
      */
-    public function getDescriptorsByBaseType($baseType)
+    public function getDescriptorsByBaseType(string $baseType): array
     {
         $output = [];
 
         if (in_array($baseType, self::$baseTypes, true)) {
-            foreach ($this->getCollection() as $descriptor) {
-                if ($this->checkBaseType($descriptor, $baseType)) {
+            foreach ($this->collection as $descriptor) {
+                if ($this->isBaseType($descriptor, $baseType)) {
                     $output[] = $this->getDescriptorByType($descriptor->getSystemName());
                 }
             }
@@ -62,51 +45,37 @@ class ContentTypeManager extends SmartlingFactoryAbstract
         return $output;
     }
 
-    /**
-     * @param ContentTypeInterface $descriptor
-     * @param string               $type see: self::$baseTypes
-     *
-     * @return bool
-     */
-    private function checkBaseType(ContentTypeInterface $descriptor, $type)
+    private function isBaseType(ContentTypeInterface $descriptor, string $type): bool
     {
         return true === call_user_func_array([$descriptor, 'is' . ucfirst($type)], []);
     }
 
     public function getRegisteredContentTypes(): array
     {
-        return array_keys($this->getCollection());
+        return array_keys($this->collection);
     }
 
-    public function getRestrictedForBulkSubmit()
+    public function getRestrictedForBulkSubmit(): array
     {
         $output = [];
-
-
-            foreach ($this->getCollection() as $descriptor) {
-                /**
-                 * @var ContentTypeInterface $descriptor
-                 */
-                if (false === $descriptor->getVisibility()['bulkSubmit']) {
-                    $output[] = $descriptor->getSystemName();
-                }
+        foreach ($this->collection as $descriptor) {
+            if (!$descriptor instanceof ContentTypeInterface) {
+                throw new SmartlingConfigException(ContentTypeInterface::class . ' expected');
             }
-
+            if (false === $descriptor->getVisibility()['bulkSubmit']) {
+                $output[] = $descriptor->getSystemName();
+            }
+        }
 
         return $output;
     }
 
-    public function getHandler(string $contentType)
+    public function getHandler(string $contentType): ContentTypeInterface
     {
-        if (array_key_exists($contentType, $this->getCollection())) {
-            return $this->getCollection()[$contentType];
-        } else {
-            if (true === $this->getAllowDefault() && null !== $this->getDefaultHandler()) {
-                return $this->getDefaultHandler();
-            } else {
-                $message = vsprintf($this->message, [$contentType, get_called_class()]);
-                throw new SmartlingInvalidFactoryArgumentException($message);
-            }
+        if (array_key_exists($contentType, $this->collection)) {
+            return $this->collection[$contentType];
         }
+
+        throw new SmartlingInvalidFactoryArgumentException(sprintf($this->message, $contentType, get_called_class()));
     }
 }

--- a/inc/Smartling/ContentTypes/ContentTypeNavigationMenu.php
+++ b/inc/Smartling/ContentTypes/ContentTypeNavigationMenu.php
@@ -45,7 +45,7 @@ class ContentTypeNavigationMenu extends TermBasedContentTypeAbstract
      * @param ContainerBuilder $di
      * @param string $manager
      */
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager')
+    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);

--- a/inc/Smartling/ContentTypes/ContentTypeNavigationMenu.php
+++ b/inc/Smartling/ContentTypes/ContentTypeNavigationMenu.php
@@ -45,7 +45,7 @@ class ContentTypeNavigationMenu extends TermBasedContentTypeAbstract
      * @param ContainerBuilder $di
      * @param string $manager
      */
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
+    public static function register(ContainerBuilder $di, string $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);

--- a/inc/Smartling/ContentTypes/ContentTypeNavigationMenuItem.php
+++ b/inc/Smartling/ContentTypes/ContentTypeNavigationMenuItem.php
@@ -70,12 +70,9 @@ class ContentTypeNavigationMenuItem extends PostBasedContentTypeAbstract
 
     }
 
-    public function getVisibility(): array
+    public function isVisible(string $page): bool
     {
-        return [
-            'submissionBoard' => true,
-            'bulkSubmit' => false,
-        ];
+        return $page === 'submissionBoard';
     }
 
     /**

--- a/inc/Smartling/ContentTypes/ContentTypeNavigationMenuItem.php
+++ b/inc/Smartling/ContentTypes/ContentTypeNavigationMenuItem.php
@@ -32,9 +32,9 @@ class ContentTypeNavigationMenuItem extends PostBasedContentTypeAbstract
 
     /**
      * @param ContainerBuilder $di
-     * @param string           $manager
+     * @param string $manager
      */
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
+    public static function register(ContainerBuilder $di, string $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);

--- a/inc/Smartling/ContentTypes/ContentTypeNavigationMenuItem.php
+++ b/inc/Smartling/ContentTypes/ContentTypeNavigationMenuItem.php
@@ -34,7 +34,7 @@ class ContentTypeNavigationMenuItem extends PostBasedContentTypeAbstract
      * @param ContainerBuilder $di
      * @param string           $manager
      */
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager')
+    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);
@@ -70,11 +70,11 @@ class ContentTypeNavigationMenuItem extends PostBasedContentTypeAbstract
 
     }
 
-    public function getVisibility()
+    public function getVisibility(): array
     {
         return [
             'submissionBoard' => true,
-            'bulkSubmit'      => false,
+            'bulkSubmit' => false,
         ];
     }
 

--- a/inc/Smartling/ContentTypes/ContentTypePluggableInterface.php
+++ b/inc/Smartling/ContentTypes/ContentTypePluggableInterface.php
@@ -6,9 +6,11 @@ use Smartling\Submissions\SubmissionEntity;
 
 interface ContentTypePluggableInterface
 {
-    public function canHandle(string $contentType, int $contentId): bool;
+    public function canHandle(string $contentType, ?int $contentId = null): bool;
 
     public function getContentFields(SubmissionEntity $submission, bool $raw): array;
+
+    public function getExternalContentTypes(): array;
 
     public function getMaxVersion(): string;
 

--- a/inc/Smartling/ContentTypes/ContentTypeWidget.php
+++ b/inc/Smartling/ContentTypes/ContentTypeWidget.php
@@ -4,18 +4,8 @@ namespace Smartling\ContentTypes;
 
 use Smartling\Vendor\Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Class ContentTypeWidget
- * @package Smartling\ContentTypes
- */
 class ContentTypeWidget extends ContentTypeAbstract
 {
-
-    /**
-     * ContentTypeWidget constructor.
-     *
-     * @param ContainerBuilder $di
-     */
     public function __construct(ContainerBuilder $di)
     {
         parent::__construct($di);
@@ -25,11 +15,7 @@ class ContentTypeWidget extends ContentTypeAbstract
         $this->registerFilters();
     }
 
-    /**
-     * @param ContainerBuilder $di
-     * @param string           $manager
-     */
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager')
+    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);
@@ -49,7 +35,7 @@ class ContentTypeWidget extends ContentTypeAbstract
      * Wordpress name of content-type, e.g.: post, page, post-tag
      * @return string
      */
-    public function getSystemName()
+    public function getSystemName(): string
     {
         return static::WP_CONTENT_TYPE;
     }
@@ -58,23 +44,9 @@ class ContentTypeWidget extends ContentTypeAbstract
      * Display name of content type, e.g.: Post
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return __('Theme Widget');
-    }
-
-    /**
-     * @return array [
-     *  'submissionBoard'   => true|false,
-     *  'bulkSubmit'        => true|false
-     * ]
-     */
-    public function getVisibility()
-    {
-        return [
-            'submissionBoard' => true,
-            'bulkSubmit'      => true,
-        ];
     }
 
     /**
@@ -115,12 +87,12 @@ class ContentTypeWidget extends ContentTypeAbstract
      * Base type can be 'post' or 'term' used for Multilingual Press plugin.
      * @return string
      */
-    public function getBaseType()
+    public function getBaseType(): string
     {
         return 'virtual';
     }
 
-    public function isVirtual()
+    public function isVirtual(): bool
     {
         return true;
     }

--- a/inc/Smartling/ContentTypes/ContentTypeWidget.php
+++ b/inc/Smartling/ContentTypes/ContentTypeWidget.php
@@ -15,7 +15,7 @@ class ContentTypeWidget extends ContentTypeAbstract
         $this->registerFilters();
     }
 
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
+    public static function register(ContainerBuilder $di, string $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);

--- a/inc/Smartling/ContentTypes/CustomTypeTrait.php
+++ b/inc/Smartling/ContentTypes/CustomTypeTrait.php
@@ -35,7 +35,7 @@ trait CustomTypeTrait
     /**
      * @return string
      */
-    public function getSystemName()
+    public function getSystemName(): string
     {
         return $this->systemName;
     }
@@ -72,7 +72,7 @@ trait CustomTypeTrait
      * Display name of content type, e.g.: Post
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label;
     }
@@ -160,7 +160,7 @@ trait CustomTypeTrait
      *  'bulkSubmit'        => true|false
      * ]
      */
-    public function getVisibility()
+    public function getVisibility(): array
     {
         return $this->getConfigParser()->getVisibility();
     }

--- a/inc/Smartling/ContentTypes/CustomTypeTrait.php
+++ b/inc/Smartling/ContentTypes/CustomTypeTrait.php
@@ -154,14 +154,8 @@ trait CustomTypeTrait
         $descriptor->registerFilters();
     }
 
-    /**
-     * @return array [
-     *  'submissionBoard'   => true|false,
-     *  'bulkSubmit'        => true|false
-     * ]
-     */
-    public function getVisibility(): array
+    public function isVisible(string $page): bool
     {
-        return $this->getConfigParser()->getVisibility();
+        return $this->getConfigParser()->getVisibility($page);
     }
 }

--- a/inc/Smartling/ContentTypes/ExternalContentAbstract.php
+++ b/inc/Smartling/ContentTypes/ExternalContentAbstract.php
@@ -22,7 +22,7 @@ abstract class ExternalContentAbstract implements ContentTypePluggableInterface 
         $this->wpProxy = $wpProxy;
     }
 
-    public function canHandle(string $contentType, int $contentId): bool
+    public function canHandle(string $contentType, ?int $contentId = null): bool
     {
         $plugins = $this->wpProxy->get_plugins();
         if (array_key_exists($this->getPluginPath(), $plugins)) {
@@ -31,6 +31,11 @@ abstract class ExternalContentAbstract implements ContentTypePluggableInterface 
         }
 
         return false;
+    }
+
+    public function getExternalContentTypes(): array
+    {
+        return [];
     }
 
     public function getRelatedContent(string $contentType, int $contentId): array

--- a/inc/Smartling/ContentTypes/ExternalContentAioseo.php
+++ b/inc/Smartling/ContentTypes/ExternalContentAioseo.php
@@ -93,7 +93,7 @@ class ExternalContentAioseo extends ExternalContentAbstract
         $this->siteHelper = $siteHelper;
     }
 
-    public function canHandle(string $contentType, int $contentId): bool
+    public function canHandle(string $contentType, ?int $contentId = null): bool
     {
         return parent::canHandle($contentType, $contentId) &&
             $this->contentTypeHelper->isPost($contentType);
@@ -101,7 +101,6 @@ class ExternalContentAioseo extends ExternalContentAbstract
 
     public function getContentFields(SubmissionEntity $submission, bool $raw): array
     {
-        $submission->assertHasSource();
         $fields = $this->siteHelper->withBlog($submission->getSourceBlogId(), function () use ($submission) {
             return $this->db->fetchPrepared('select * from ' . $this->db->getPrefix() . 'aioseo_posts where post_id = %d', $submission->getSourceId())[0] ?? [];
         });

--- a/inc/Smartling/ContentTypes/ExternalContentBeaverBuilder.php
+++ b/inc/Smartling/ContentTypes/ExternalContentBeaverBuilder.php
@@ -60,7 +60,7 @@ class ExternalContentBeaverBuilder extends ExternalContentAbstract implements Co
         return $source;
     }
 
-    public function canHandle(string $contentType, int $contentId): bool
+    public function canHandle(string $contentType, ?int $contentId = null): bool
     {
         return parent::canHandle($contentType, $contentId) &&
             $this->contentTypeHelper->isPost($contentType) &&
@@ -92,7 +92,6 @@ class ExternalContentBeaverBuilder extends ExternalContentAbstract implements Co
 
     public function getContentFields(SubmissionEntity $submission, bool $raw): array
     {
-        $submission->assertHasSource();
         return $this->extractContent($this->getDataFromPostMeta($submission->getSourceId()))->getStrings();
     }
 

--- a/inc/Smartling/ContentTypes/ExternalContentElementor.php
+++ b/inc/Smartling/ContentTypes/ExternalContentElementor.php
@@ -146,7 +146,7 @@ class ExternalContentElementor extends ExternalContentAbstract implements Conten
         return $source;
     }
 
-    public function canHandle(string $contentType, int $contentId): bool
+    public function canHandle(string $contentType, ?int $contentId = null): bool
     {
         return parent::canHandle($contentType, $contentId) &&
             $this->contentTypeHelper->isPost($contentType) &&
@@ -198,7 +198,6 @@ class ExternalContentElementor extends ExternalContentAbstract implements Conten
 
     public function getContentFields(SubmissionEntity $submission, bool $raw): array
     {
-        $submission->assertHasSource();
         return $this->extractContent($this->getElementorDataFromPostMeta($submission->getSourceId()))->getStrings();
     }
 

--- a/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
+++ b/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Smartling\ContentTypes;
+
+use Smartling\DbAl\WordpressContentEntities\GravityFormsFormHandler;
+use Smartling\Helpers\FieldsFilterHelper;
+use Smartling\Helpers\GutenbergBlockHelper;
+use Smartling\Helpers\LoggerSafeTrait;
+use Smartling\Helpers\PluginHelper;
+use Smartling\Helpers\SiteHelper;
+use Smartling\Helpers\WordpressFunctionProxyHelper;
+use Smartling\Processors\ContentEntitiesIOFactory;
+use Smartling\Submissions\SubmissionEntity;
+use Smartling\Submissions\SubmissionManager;
+
+class ExternalContentGravityForms extends ExternalContentAbstract implements ContentTypeModifyingInterface {
+    use LoggerSafeTrait;
+
+    public const CONTENT_TYPE = 'gravityforms-form';
+    private ContentTypeHelper $contentTypeHelper;
+    private GravityFormsFormHandler $handler;
+    private GutenbergBlockHelper $gutenbergBlockHelper;
+    private SiteHelper $siteHelper;
+    private FieldsFilterHelper $fieldsFilterHelper;
+
+    public function __construct(
+        ContentEntitiesIOFactory $contentEntitiesIOFactory,
+        ContentTypeManager $contentTypeManager,
+        ContentTypeHelper $contentTypeHelper,
+        FieldsFilterHelper $fieldsFilterHelper,
+        GravityFormsForm $contentType,
+        GravityFormsFormHandler $handler,
+        GutenbergBlockHelper $gutenbergBlockHelper,
+        PluginHelper $pluginHelper,
+        SiteHelper $siteHelper,
+        SubmissionManager $submissionManager,
+        WordpressFunctionProxyHelper $wpProxy,
+    ) {
+        parent::__construct($pluginHelper, $submissionManager, $wpProxy);
+        $this->contentTypeHelper = $contentTypeHelper;
+        $this->fieldsFilterHelper = $fieldsFilterHelper;
+        $this->gutenbergBlockHelper = $gutenbergBlockHelper;
+        $this->handler = $handler;
+        $this->siteHelper = $siteHelper;
+        if (parent::canHandle(self::CONTENT_TYPE)) {
+            $contentEntitiesIOFactory->registerHandler(self::CONTENT_TYPE, $handler);
+            $contentTypeManager->addDescriptor($contentType);
+        }
+    }
+
+    public function alterContentFieldsForUpload(array $source): array
+    {
+        unset($source['display_meta']);
+        return $source;
+    }
+
+    public function canHandle(string $contentType, ?int $contentId = null): bool
+    {
+        return parent::canHandle($contentType, $contentId) &&
+            ($contentType === self::CONTENT_TYPE || $this->contentTypeHelper->isPost($contentType));
+    }
+
+    public function getContentFields(SubmissionEntity $submission, bool $raw): array
+    {
+        /*$fields = $this->siteHelper->withBlog($submission->getSourceBlogId(), function () use ($submission) {
+            return [
+                'entity' => $this->handler->getFormData($submission->getSourceId()),
+                'meta' => $this->handler->getMeta($submission->getSourceId()),
+            ];
+        });*/
+        $form = $this->handler->getFormData($submission->getSourceId());
+        $meta = $this->handler->getMeta($submission->getSourceId());
+        $displayMeta = json_decode($meta['display_meta'], true, 512, JSON_THROW_ON_ERROR);
+
+        $confirmations = [];
+        foreach ($displayMeta['confirmations'] as $key => $confirmation) {
+            $confirmations[$key] = [
+                'name' => $confirmation['name'],
+                'message' => $confirmation['message'],
+            ];
+        }
+
+        return [
+            'title' => $form['title'],
+            'displayMeta' => [
+                'title' => $displayMeta['title'],
+                'description' => $displayMeta['description'],
+                'button' => [
+                    'text' => $displayMeta['button']['text'],
+                ],
+                'fields' => array_map(static function ($field) {
+                    return [
+                        'label' => $field['label'],
+                        'adminLabel' => $field['adminLabel'],
+                        'errorMessage' => $field['errorMessage'],
+                        'description' => $field['description'],
+                        'placeholder' => $field['placeholder'],
+                        'defaultValue' => $field['defaultValue'],
+                        'checkboxLabel' => $field['checkboxLabel'],
+                    ];
+                }, $displayMeta['fields'] ?? []),
+                'confirmations' => $confirmations,
+                'customRequiredIndicator' => $displayMeta['customRequiredIndicator'],
+                'buttonText' => $displayMeta['buttonText'],
+                'saveButtonText' => $displayMeta['saveButtonText'],
+                'limitEntriesMessage' => $displayMeta['limitEntriesMessage'],
+                'schedulePendingMessage' => $displayMeta['schedulePendingMessage'],
+                'scheduleMessage' => $displayMeta['scheduleMessage'],
+                'requireLoginMessage' => $displayMeta['requireLoginMessage'],
+                'save' => [
+                    'button' => [
+                        'text' => $displayMeta['save']['button']['text'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getExternalContentTypes(): array
+    {
+        return [self::CONTENT_TYPE];
+    }
+
+    public function getMaxVersion(): string
+    {
+        return '2.5.9.3';
+    }
+
+    public function getMinVersion(): string
+    {
+        return '2.5.9.3';
+    }
+
+    public function getPluginId(): string
+    {
+        return 'gravity_forms';
+    }
+
+    public function getPluginPath(): string
+    {
+        return 'gravityforms/gravityforms.php';
+    }
+
+    public function getRelatedContent(string $contentType, int $contentId): array
+    {
+        $result = [];
+        foreach ($this->gutenbergBlockHelper->parseBlocks($this->wpProxy->get_post($contentId, ARRAY_A)['post_content'] ?? '') as $block) {
+            if ($block->getBlockName() === 'gravityforms/form') {
+                foreach ($block->getAttributes() as $attribute => $value) {
+                    if ($attribute === 'formId') {
+                        $result[self::CONTENT_TYPE][] = (int)$value;
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    public function setContentFields(array $original, array $translation, SubmissionEntity $submission): ?array
+    {
+        $result = $original;
+        $result['entity']['title'] = $translation[$this->getPluginId()]['title'];
+        $displayMeta = json_decode($result['entity']['displayMeta'], true, 512, JSON_THROW_ON_ERROR);
+        $result['entity']['displayMeta'] = json_encode($this->fieldsFilterHelper->structurizeArray(array_merge(
+            $this->fieldsFilterHelper->flattenArray($displayMeta),
+            $this->fieldsFilterHelper->flattenArray($translation[$this->getPluginId()]['displayMeta']),
+        )), JSON_THROW_ON_ERROR);
+        $translation['entity'] = $result['entity'];
+        unset($translation[$this->getPluginId()]);
+        return $translation;
+    }
+}

--- a/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
+++ b/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
@@ -51,7 +51,7 @@ class ExternalContentGravityForms extends ExternalContentAbstract implements Con
 
     public function alterContentFieldsForUpload(array $source): array
     {
-        unset($source['display_meta']);
+        unset($source['entity']['displayMeta']);
         return $source;
     }
 
@@ -72,7 +72,7 @@ class ExternalContentGravityForms extends ExternalContentAbstract implements Con
         $displayMeta = json_decode($formData->getDisplayMeta(), true, 512, JSON_THROW_ON_ERROR);
 
         $confirmations = [];
-        foreach ($displayMeta['confirmations'] as $key => $confirmation) {
+        foreach ($displayMeta['confirmations'] ?? [] as $key => $confirmation) {
             $confirmations[$key] = [
                 'name' => $confirmation['name'],
                 'message' => $confirmation['message'],
@@ -83,34 +83,56 @@ class ExternalContentGravityForms extends ExternalContentAbstract implements Con
             'title' => $formData->getTitle(),
             'displayMeta' => [
                 'title' => $displayMeta['title'],
-                'description' => $displayMeta['description'],
                 'button' => [
                     'text' => $displayMeta['button']['text'],
                 ],
-                'fields' => array_map(static function ($field) {
-                    return [
-                        'label' => $field['label'],
-                        'adminLabel' => $field['adminLabel'],
-                        'errorMessage' => $field['errorMessage'],
-                        'description' => $field['description'],
-                        'placeholder' => $field['placeholder'],
-                        'defaultValue' => $field['defaultValue'],
-                        'checkboxLabel' => $field['checkboxLabel'],
-                    ];
-                }, $displayMeta['fields'] ?? []),
+                'buttonText' => $displayMeta['buttonText'],
                 'confirmations' => $confirmations,
                 'customRequiredIndicator' => $displayMeta['customRequiredIndicator'],
-                'buttonText' => $displayMeta['buttonText'],
-                'saveButtonText' => $displayMeta['saveButtonText'],
+                'description' => $displayMeta['description'],
+                'fields' => array_map(static function ($field) {
+                    $choices = $field['choices'] ?? [];
+                    if (is_array($field['choices'])) {
+                        $choices = array_map(static function ($choice) {
+                            return [
+                                'text' => $choice['text'],
+                                'value' => $choice['value'],
+                            ];
+                        }, $field['choices']);
+                    }
+
+                    $inputs = $field['inputs'] ?? [];
+                    if (is_array($field['inputs'])) {
+                        $inputs = array_map(static function ($input) {
+                            return [
+                                'label' => $input['label'],
+                            ];
+                        }, $field['inputs']);
+                    }
+
+                    return [
+                        'adminLabel' => $field['adminLabel'],
+                        'checkboxLabel' => $field['checkboxLabel'] ?? '',
+                        'choices' => $choices,
+                        'content' => $field['content'] ?? '',
+                        'defaultValue' => $field['defaultValue'],
+                        'description' => $field['description'],
+                        'errorMessage' => $field['errorMessage'],
+                        'inputs' => $inputs,
+                        'label' => $field['label'],
+                        'placeholder' => $field['placeholder'],
+                    ];
+                }, $displayMeta['fields'] ?? []),
                 'limitEntriesMessage' => $displayMeta['limitEntriesMessage'],
-                'schedulePendingMessage' => $displayMeta['schedulePendingMessage'],
-                'scheduleMessage' => $displayMeta['scheduleMessage'],
                 'requireLoginMessage' => $displayMeta['requireLoginMessage'],
                 'save' => [
                     'button' => [
                         'text' => $displayMeta['save']['button']['text'],
                     ],
                 ],
+                'saveButtonText' => $displayMeta['saveButtonText'],
+                'schedulePendingMessage' => $displayMeta['schedulePendingMessage'],
+                'scheduleMessage' => $displayMeta['scheduleMessage'],
             ],
         ];
     }

--- a/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
+++ b/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
@@ -62,15 +62,13 @@ class ExternalContentGravityForms extends ExternalContentAbstract implements Con
 
     public function getContentFields(SubmissionEntity $submission, bool $raw): array
     {
-        /*$fields = $this->siteHelper->withBlog($submission->getSourceBlogId(), function () use ($submission) {
+        $fields = $this->siteHelper->withBlog($submission->getSourceBlogId(), function () use ($submission) {
             return [
                 'entity' => $this->handler->getFormData($submission->getSourceId()),
                 'meta' => $this->handler->getMeta($submission->getSourceId()),
             ];
-        });*/
-        $form = $this->handler->getFormData($submission->getSourceId());
-        $meta = $this->handler->getMeta($submission->getSourceId());
-        $displayMeta = json_decode($meta['display_meta'], true, 512, JSON_THROW_ON_ERROR);
+        });
+        $displayMeta = json_decode($fields['meta']['display_meta'], true, 512, JSON_THROW_ON_ERROR);
 
         $confirmations = [];
         foreach ($displayMeta['confirmations'] as $key => $confirmation) {
@@ -81,7 +79,7 @@ class ExternalContentGravityForms extends ExternalContentAbstract implements Con
         }
 
         return [
-            'title' => $form['title'],
+            'title' => $fields['entity']['title'],
             'displayMeta' => [
                 'title' => $displayMeta['title'],
                 'description' => $displayMeta['description'],

--- a/inc/Smartling/ContentTypes/ExternalContentManager.php
+++ b/inc/Smartling/ContentTypes/ExternalContentManager.php
@@ -26,6 +26,7 @@ class ExternalContentManager
             if ($handler->canHandle($submission->getContentType(), $submission->getSourceId())) {
                 $this->getLogger()->debug("Determined support for {$handler->getPluginId()}, will try to get fields");
                 try {
+                    $submission->assertHasSource();
                     $source[$handler->getPluginId()] = $handler->getContentFields($submission, $raw);
                 } catch (\Throwable $e) {
                     $this->getLogger()->notice('HandlerName="' . $handler->getPluginId() . '" got exception while trying to get external content: ' . $e->getMessage());
@@ -41,6 +42,16 @@ class ExternalContentManager
         }
 
         return $source;
+    }
+
+    public function getExternalContentTypes(): array
+    {
+        $result = [];
+        foreach ($this->handlers as $handler) {
+            $result[] = $handler->getExternalContentTypes();
+        }
+
+        return array_merge(...$result);
     }
 
     public function getExternalRelations(string $contentType, int $id): array

--- a/inc/Smartling/ContentTypes/GravityFormsForm.php
+++ b/inc/Smartling/ContentTypes/GravityFormsForm.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Smartling\ContentTypes;
+
+class GravityFormsForm extends ContentTypeAbstract {
+    public function __construct()
+    {
+    }
+
+    public function getSystemName(): string
+    {
+        return ExternalContentGravityForms::CONTENT_TYPE;
+    }
+
+    public function getLabel(): string
+    {
+        return 'Gravity Forms Form';
+    }
+
+    public function getBaseType(): string
+    {
+        return ContentTypeManager::VIRTUAL;
+    }
+
+    public function isVirtual(): bool
+    {
+        return true;
+    }
+}

--- a/inc/Smartling/ContentTypes/GravityFormsForm.php
+++ b/inc/Smartling/ContentTypes/GravityFormsForm.php
@@ -2,11 +2,7 @@
 
 namespace Smartling\ContentTypes;
 
-class GravityFormsForm extends ContentTypeAbstract {
-    public function __construct()
-    {
-    }
-
+class GravityFormsForm extends UnregisteredContentTypeAbstract {
     public function getSystemName(): string
     {
         return ExternalContentGravityForms::CONTENT_TYPE;

--- a/inc/Smartling/ContentTypes/PostBasedContentTypeAbstract.php
+++ b/inc/Smartling/ContentTypes/PostBasedContentTypeAbstract.php
@@ -19,7 +19,7 @@ abstract class PostBasedContentTypeAbstract extends ContentTypeAbstract
      * Wordpress name of content-type, e.g.: post, page, post-tag
      * @return string
      */
-    public function getSystemName()
+    public function getSystemName(): string
     {
         return static::WP_CONTENT_TYPE;
     }
@@ -28,7 +28,7 @@ abstract class PostBasedContentTypeAbstract extends ContentTypeAbstract
      * Base type can be 'post' or 'term' used for Multilingual Press plugin.
      * @return string
      */
-    public function getBaseType()
+    public function getBaseType(): string
     {
         return 'post';
     }
@@ -37,7 +37,7 @@ abstract class PostBasedContentTypeAbstract extends ContentTypeAbstract
      * Display name of content type, e.g.: Post
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         $systemName = static::getSystemName();
         $result = WordpressFunctionProxyHelper::getPostTypes(['name' => $systemName], 'objects');
@@ -50,23 +50,9 @@ abstract class PostBasedContentTypeAbstract extends ContentTypeAbstract
     }
 
     /**
-     * @return array [
-     *  'submissionBoard'   => true|false,
-     *  'bulkSubmit'        => true|false
-     * ]
-     */
-    public function getVisibility()
-    {
-        return [
-            'submissionBoard' => true,
-            'bulkSubmit'      => true,
-        ];
-    }
-
-    /**
      * @return bool
      */
-    public function isPost()
+    public function isPost(): bool
     {
         return true;
     }

--- a/inc/Smartling/ContentTypes/TermBasedContentTypeAbstract.php
+++ b/inc/Smartling/ContentTypes/TermBasedContentTypeAbstract.php
@@ -19,7 +19,7 @@ abstract class TermBasedContentTypeAbstract extends ContentTypeAbstract
      * Wordpress name of content-type, e.g.: post, page, post-tag
      * @return string
      */
-    public function getSystemName()
+    public function getSystemName(): string
     {
         return static::WP_CONTENT_TYPE;
     }
@@ -28,7 +28,7 @@ abstract class TermBasedContentTypeAbstract extends ContentTypeAbstract
      * Base type can be 'post' or 'term' used for Multilingual Press plugin.
      * @return string
      */
-    public function getBaseType()
+    public function getBaseType(): string
     {
         return 'taxonomy';
     }
@@ -37,7 +37,7 @@ abstract class TermBasedContentTypeAbstract extends ContentTypeAbstract
      * Display name of content type, e.g.: Post
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         $systemName = static::getSystemName();
         $result = WordpressFunctionProxyHelper::getTaxonomies(['name' => $systemName], 'objects');
@@ -50,23 +50,9 @@ abstract class TermBasedContentTypeAbstract extends ContentTypeAbstract
     }
 
     /**
-     * @return array [
-     *  'submissionBoard'   => true|false,
-     *  'bulkSubmit'        => true|false
-     * ]
-     */
-    public function getVisibility()
-    {
-        return [
-            'submissionBoard' => true,
-            'bulkSubmit'      => true,
-        ];
-    }
-
-    /**
      * @return bool
      */
-    public function isTaxonomy()
+    public function isTaxonomy(): bool
     {
         return true;
     }

--- a/inc/Smartling/ContentTypes/UnregisteredContentTypeAbstract.php
+++ b/inc/Smartling/ContentTypes/UnregisteredContentTypeAbstract.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Smartling\ContentTypes;
+
+use Smartling\Exception\SmartlingConfigException;
+use Smartling\Vendor\Symfony\Component\DependencyInjection\ContainerBuilder;
+
+abstract class UnregisteredContentTypeAbstract implements ContentTypeInterface
+{
+    public function isVisible(string $page): bool
+    {
+        return true;
+    }
+
+    public function isTaxonomy(): bool
+    {
+        return false;
+    }
+
+    public function isPost(): bool
+    {
+        return false;
+    }
+
+    public function isVirtual(): bool
+    {
+        return false;
+    }
+
+    public function forceDisplay(): bool
+    {
+        return false;
+    }
+}

--- a/inc/Smartling/DbAl/Migrations/DbMigrationManager.php
+++ b/inc/Smartling/DbAl/Migrations/DbMigrationManager.php
@@ -4,11 +4,6 @@ namespace Smartling\DbAl\Migrations;
 
 use Smartling\Processors\SmartlingFactoryAbstract;
 
-/**
- * Class DbMigrationManager
- *
- * @package Smartling\DbAl\Migrations
- */
 class DbMigrationManager extends SmartlingFactoryAbstract
 {
     /** @noinspection PhpUnused, used in DI */
@@ -23,7 +18,7 @@ class DbMigrationManager extends SmartlingFactoryAbstract
     public function getMigrations(int $fromVersion): array
     {
         $pool = [];
-        foreach ($this->getCollection() as $version => $migration) {
+        foreach ($this->collection as $version => $migration) {
             if ($version > $fromVersion) {
                 $pool[] = $migration;
             }
@@ -37,7 +32,7 @@ class DbMigrationManager extends SmartlingFactoryAbstract
     {
         $ver = 0;
 
-        foreach ($this->getCollection() as $version => $migration) {
+        foreach ($this->collection as $version => $migration) {
             $ver = max($ver, $version);
         }
 

--- a/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
@@ -2,7 +2,7 @@
 
 namespace Smartling\DbAl\WordpressContentEntities;
 
-use JetBrains\PhpStorm\ArrayShape;
+use Smartling\WP\View\BulkSubmitScreenRow;
 
 interface Entity {
     public function fromArray(array $array): self;
@@ -13,14 +13,5 @@ interface Entity {
 
     public function toArray(): array;
 
-    #[ArrayShape([
-        'author' => 'string',
-        'id' => 'mixed',
-        'status' => 'string',
-        'title' => 'string',
-        'locales' => 'string',
-        'type' => 'string',
-        'updated' => 'string',
-    ])]
-    public function toBulkSubmitScreenRow(): array;
+    public function toBulkSubmitScreenRow(): BulkSubmitScreenRow;
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
@@ -9,7 +9,7 @@ interface Entity {
 
     public function getId(): ?int;
 
-    public function getRelatedContentTypes(): array;
+    public function getRelatedTypes(): array;
 
     public function getTitle(): string;
 

--- a/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
@@ -4,7 +4,7 @@ namespace Smartling\DbAl\WordpressContentEntities;
 
 use JetBrains\PhpStorm\ArrayShape;
 
-interface EntityInterface {
+interface Entity {
     public function fromArray(array $array): self;
 
     public function getId(): ?int;

--- a/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
@@ -5,6 +5,8 @@ namespace Smartling\DbAl\WordpressContentEntities;
 use Smartling\WP\View\BulkSubmitScreenRow;
 
 interface Entity {
+    public function forInsert(): self;
+
     public function fromArray(array $array): self;
 
     public function getId(): ?int;

--- a/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
@@ -18,6 +18,7 @@ interface Entity {
         'id' => 'mixed',
         'status' => 'string',
         'title' => 'string',
+        'locales' => 'string',
         'type' => 'string',
         'updated' => 'string',
     ])]

--- a/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/Entity.php
@@ -9,6 +9,8 @@ interface Entity {
 
     public function getId(): ?int;
 
+    public function getRelatedContentTypes(): array;
+
     public function getTitle(): string;
 
     public function toArray(): array;

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
@@ -9,69 +9,39 @@ use Smartling\Helpers\WordpressContentTypeHelper;
 use Smartling\MonologWrapper\MonologWrapper;
 use Smartling\Vendor\Psr\Log\LoggerInterface;
 
-abstract class EntityAbstract implements Entity
+abstract class EntityAbstract implements Entity, EntityHandler
 {
     use LoggerTrait;
 
-    /**
-     * @var string
-     */
-    protected $type = 'abstract';
+    protected string $type = 'abstract';
 
     /**
      * List of fields that affect the hash of the entity
-     * @var array
      */
-    protected $hashAffectingFields = [];
+    protected array $hashAffectingFields = [];
 
-    /**
-     * @var array
-     */
-    private $entityFields = ['hash'];
+    private array $entityFields = ['hash'];
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * @var array List of related content-types to search
      */
-    private $relatedTypes = [];
+    private array $relatedTypes = [];
 
-    /**
-     * @return array
-     */
-    public function getRelatedTypes()
+    public function getRelatedTypes(): array
     {
         return $this->relatedTypes;
     }
 
-    /**
-     * @param array $relatedTypes
-     */
-    public function setRelatedTypes($relatedTypes)
+    public function setRelatedTypes(array $relatedTypes): void
     {
         $this->relatedTypes = $relatedTypes;
     }
 
-    public function resetRelatedTypes()
-    {
-        $this->relatedTypes = [];
-    }
+    private array $entityArrayState = [];
 
-    /**
-     * @param string $relatedType
-     */
-    public function addRelatedType($relatedType)
-    {
-        $this->relatedTypes[] = $relatedType;
-    }
-
-
-    private $entityArrayState = [];
-
-    private function initEntityArrayState()
+    private function initEntityArrayState(): void
     {
         if (0 === count($this->entityArrayState)) {
             foreach ($this->entityFields as $field) {
@@ -126,33 +96,17 @@ abstract class EntityAbstract implements Entity
         }
     }
 
-    /**
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function __isset($name)
+    public function __isset(string $name): bool
     {
         return array_key_exists($name, $this->entityArrayState);
     }
 
-    /**
-     * @param string $method
-     *
-     * @return string
-     */
-    protected function getFieldNameByMethodName($method)
+    protected function getFieldNameByMethodName(string $method): string
     {
         return strtolower(preg_replace('/([A-Z])/', '_$1', lcfirst(substr($method, 3))));
     }
 
-    /**
-     * @param string $method
-     * @param array  $params
-     *
-     * @return mixed|void
-     */
-    public function __call($method, array $params)
+    public function __call(string $method, array $params): mixed
     {
         switch (substr($method, 0, 3)) {
             case 'set' :
@@ -163,24 +117,15 @@ abstract class EntityAbstract implements Entity
                 $field = $this->getFieldNameByMethodName($method);
 
                 return $this->$field; // get the very first arg
-            default :
-                $template = 'Method \'%s\' does not exists in class \'%s\'';
-                $message = vsprintf($template, [$method, get_class($this)]);
-                throw new \BadMethodCallException($message);
         }
+        throw new \BadMethodCallException(sprintf("Method $method does not exists in class '%s'", get_class($this)));
     }
 
     abstract public function getTitle(): string;
 
-    /**
-     * @return string
-     */
-    abstract public function getContentTypeProperty();
+    abstract public function getContentTypeProperty(): string;
 
-    /**
-     * @return bool
-     */
-    protected function validateContentType()
+    protected function validateContentType(): bool
     {
         if ($this instanceof VirtualEntityAbstract) {
             return true;
@@ -199,18 +144,11 @@ abstract class EntityAbstract implements Entity
         return true;
     }
 
-
-    /**
-     * @return LoggerInterface
-     */
-    protected function getLogger()
+    protected function getLogger(): LoggerInterface
     {
         return $this->logger;
     }
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         $this->logger = MonologWrapper::getLogger(get_called_class());
@@ -218,44 +156,28 @@ abstract class EntityAbstract implements Entity
 
     /**
      * Loads the entity from database
-     * @param mixed $guid
-     * @return EntityAbstract
      * @throws EntityNotFoundException
      */
-    abstract public function get($guid);
+    abstract public function get(mixed $id): self;
 
     /**
-     * @param string $tagName
-     * @param string $tagValue
-     * @param bool   $unique
-     */
-    abstract public function setMetaTag($tagName, $tagValue, $unique = true): void;
-
-    /**
-     * @param int $limit
-     * @param int $offset
-     * @param string $orderBy
-     * @param string $order
-     * @param string $searchString
      * @return static[]
      */
     // FIXME TODO : Method must be static or better moved out from this class
     // It's not good idea to ask instence of Post\Tag class to return all objects
-    abstract public function getAll($limit = 0, $offset = 0, $orderBy = '', $order = '', $searchString = '');
+    abstract public function getAll(int $limit = 0, int $offset = 0, string $orderBy = '', string $order = '', string $searchString = ''): array;
 
     /**
      * @return int
      */
     // FIXME TODO : Method must be static or better moved out from this class
     // It's not good idea to ask instence of Post\Tag class to return all objects
-    abstract public function getTotal();
+    abstract public function getTotal(): int;
 
     /**
      * Stores entity to database
-     * @param EntityAbstract $entity
-     * @return int
      */
-    abstract public function set(EntityAbstract $entity = null);
+    abstract public function set(Entity $entity): int;
 
     protected function resultToEntity(array $arr): static
     {
@@ -284,43 +206,28 @@ abstract class EntityAbstract implements Entity
     /**
      * @return string[]
      */
-    abstract protected function getNonCloneableFields();
+    abstract protected function getNonCloneableFields(): array;
 
-    /**
-     * @param mixed $value
-     */
-    public function cleanFields($value = null)
+    public function cleanFields(mixed $value = null): void
     {
         foreach ($this->getNonCloneableFields() as $field) {
             $this->$field = $value;
         }
     }
 
-    /**
-     * @return string
-     */
-    abstract public function getPrimaryFieldName();
+    abstract public function getPrimaryFieldName(): string;
 
-    /**
-     * @return int
-     */
-    public function getPK()
+    public function getPK(): int
     {
         return (int)$this->{$this->getPrimaryFieldName()};
     }
 
-    /**
-     * @return string
-     */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @param string $type
-     */
-    public function setType($type)
+    public function setType($type): void
     {
         $this->type = $type;
     }

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
@@ -51,7 +51,7 @@ abstract class EntityAbstract extends EntityBase implements EntityHandler
         }
     }
 
-    public function fromArray(array $array): self
+    public function fromArray(array $array): static
     {
         $result = clone $this;
         $result->entityFields = array_merge(['hash'], $array);
@@ -213,11 +213,13 @@ abstract class EntityAbstract extends EntityBase implements EntityHandler
      */
     abstract protected function getNonCloneableFields(): array;
 
-    public function cleanFields(mixed $value = null): void
+    public function forInsert(): static
     {
-        foreach ($this->getNonCloneableFields() as $field) {
-            $this->$field = $value;
+        $result = clone $this;
+        foreach ($result->getNonCloneableFields() as $field) {
+            $result->$field = null;
         }
+        return $result;
     }
 
     abstract public function getPrimaryFieldName(): string;

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
@@ -8,6 +8,7 @@ use Smartling\Helpers\ArrayHelper;
 use Smartling\Helpers\WordpressContentTypeHelper;
 use Smartling\MonologWrapper\MonologWrapper;
 use Smartling\Vendor\Psr\Log\LoggerInterface;
+use Smartling\WP\View\BulkSubmitScreenRow;
 
 abstract class EntityAbstract implements Entity, EntityHandler
 {
@@ -238,9 +239,8 @@ abstract class EntityAbstract implements Entity, EntityHandler
 
     /**
      * Converts instance of EntityAbstract to array to be used for BulkSubmit screen
-     * @return array
      */
-    abstract public function toBulkSubmitScreenRow(): array;
+    abstract public function toBulkSubmitScreenRow(): BulkSubmitScreenRow;
 
     protected function areMetadataValuesUnique(array $metadata): bool
     {

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
@@ -9,7 +9,7 @@ use Smartling\Helpers\WordpressContentTypeHelper;
 use Smartling\MonologWrapper\MonologWrapper;
 use Smartling\Vendor\Psr\Log\LoggerInterface;
 
-abstract class EntityAbstract implements EntityInterface
+abstract class EntityAbstract implements Entity
 {
     use LoggerTrait;
 

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
@@ -10,7 +10,7 @@ use Smartling\MonologWrapper\MonologWrapper;
 use Smartling\Vendor\Psr\Log\LoggerInterface;
 use Smartling\WP\View\BulkSubmitScreenRow;
 
-abstract class EntityAbstract implements Entity, EntityHandler
+abstract class EntityAbstract extends EntityBase implements EntityHandler
 {
     use LoggerTrait;
 

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityAbstract.php
@@ -106,19 +106,23 @@ abstract class EntityAbstract implements Entity, EntityHandler
         return strtolower(preg_replace('/([A-Z])/', '_$1', lcfirst(substr($method, 3))));
     }
 
-    public function __call(string $method, array $params): mixed
+    /**
+     * @return mixed|void
+     */
+    public function __call(string $method, array $params)
     {
         switch (substr($method, 0, 3)) {
-            case 'set' :
+            case 'set':
                 $field = $this->getFieldNameByMethodName($method);
                 $this->$field = ArrayHelper::first($params); // get the very first arg
                 break;
-            case 'get' :
+            case 'get':
                 $field = $this->getFieldNameByMethodName($method);
 
                 return $this->$field; // get the very first arg
+            default:
+                throw new \BadMethodCallException(sprintf("Method $method does not exists in class '%s'", get_class($this)));
         }
-        throw new \BadMethodCallException(sprintf("Method $method does not exists in class '%s'", get_class($this)));
     }
 
     abstract public function getTitle(): string;

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityBase.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityBase.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Smartling\DbAl\WordpressContentEntities;
+
+use Smartling\WP\View\BulkSubmitScreenRow;
+
+abstract class EntityBase implements Entity {
+    public function getRelatedContentTypes(): array
+    {
+        return [];
+    }
+}

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityBase.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityBase.php
@@ -5,7 +5,7 @@ namespace Smartling\DbAl\WordpressContentEntities;
 use Smartling\WP\View\BulkSubmitScreenRow;
 
 abstract class EntityBase implements Entity {
-    public function getRelatedContentTypes(): array
+    public function getRelatedTypes(): array
     {
         return [];
     }

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityHandler.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityHandler.php
@@ -9,14 +9,12 @@ interface EntityHandler {
     /**
      * @throws EntityNotFoundException
      */
-    public function get(int $id): Entity;
+    public function get(mixed $id): Entity;
 
     /**
      * @return Entity[]
      */
     public function getAll(int $limit = 0, int $offset = 0, string $orderBy = '', string $order = '', string $searchString = ''): array;
-
-    public function getTitle(int $id): string;
 
     public function getTotal(): int;
 

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityHandler.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityHandler.php
@@ -9,10 +9,10 @@ interface EntityHandler {
     /**
      * @throws EntityNotFoundException
      */
-    public function get(int $id): EntityInterface;
+    public function get(int $id): Entity;
 
     /**
-     * @return EntityInterface[]
+     * @return Entity[]
      */
     public function getAll(int $limit = 0, int $offset = 0, string $orderBy = '', string $order = '', string $searchString = ''): array;
 
@@ -23,5 +23,5 @@ interface EntityHandler {
     /**
      * @throws SmartlingDbException
      */
-    public function set(EntityInterface $entity): int;
+    public function set(Entity $entity): int;
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityHandler.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Smartling\DbAl\WordpressContentEntities;
+
+use Smartling\Exception\EntityNotFoundException;
+use Smartling\Exception\SmartlingDbException;
+
+interface EntityHandler {
+    /**
+     * @throws EntityNotFoundException
+     */
+    public function get(int $id): EntityInterface;
+
+    /**
+     * @return EntityInterface[]
+     */
+    public function getAll(int $limit = 0, int $offset = 0, string $orderBy = '', string $order = '', string $searchString = ''): array;
+
+    public function getTitle(int $id): string;
+
+    public function getTotal(): int;
+
+    /**
+     * @throws SmartlingDbException
+     */
+    public function set(EntityInterface $entity): int;
+}

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityInterface.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Smartling\DbAl\WordpressContentEntities;
+
+use JetBrains\PhpStorm\ArrayShape;
+
+interface EntityInterface {
+    public function fromArray(array $array): self;
+
+    public function getId(): ?int;
+
+    public function getTitle(): string;
+
+    public function toArray(): array;
+
+    #[ArrayShape([
+        'author' => 'string',
+        'id' => 'mixed',
+        'status' => 'string',
+        'title' => 'string',
+        'type' => 'string',
+        'updated' => 'string',
+    ])]
+    public function toBulkSubmitScreenRow(): array;
+}

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityWithMetadata.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityWithMetadata.php
@@ -4,4 +4,6 @@ namespace Smartling\DbAl\WordpressContentEntities;
 
 interface EntityWithMetadata extends Entity {
     public function getMetadata(): array;
+
+    public function setMetaTag(string $key, mixed $value): void;
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityWithMetadata.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityWithMetadata.php
@@ -2,6 +2,6 @@
 
 namespace Smartling\DbAl\WordpressContentEntities;
 
-interface EntityWithMetadata extends EntityInterface {
+interface EntityWithMetadata extends Entity {
     public function getMetadata(): array;
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityWithMetadata.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityWithMetadata.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Smartling\DbAl\WordpressContentEntities;
+
+interface EntityWithMetadata extends EntityInterface {
+    public function getMetadata(): array;
+}

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityWithPostStatus.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityWithPostStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Smartling\DbAl\WordpressContentEntities;
+
+interface EntityWithPostStatus extends EntityInterface {
+    public function translationCompleted(): void;
+
+    public function translationDrafted(): void;
+}

--- a/inc/Smartling/DbAl/WordpressContentEntities/EntityWithPostStatus.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/EntityWithPostStatus.php
@@ -2,7 +2,7 @@
 
 namespace Smartling\DbAl\WordpressContentEntities;
 
-interface EntityWithPostStatus extends EntityInterface {
+interface EntityWithPostStatus extends Entity {
     public function translationCompleted(): void;
 
     public function translationDrafted(): void;

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormFormData.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormFormData.php
@@ -5,9 +5,9 @@ namespace Smartling\DbAl\WordpressContentEntities;
 class GravityFormFormData {
     private string $display_meta;
     private string $title;
-    private string $updated;
+    private ?string $updated;
 
-    public function __construct(string $display_meta, string $title, string $updated)
+    public function __construct(string $display_meta, string $title, ?string $updated)
     {
         $this->display_meta = $display_meta;
         $this->title = $title;
@@ -24,7 +24,7 @@ class GravityFormFormData {
         return $this->title;
     }
 
-    public function getUpdated(): string
+    public function getUpdated(): ?string
     {
         return $this->updated;
     }

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormFormData.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormFormData.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Smartling\DbAl\WordpressContentEntities;
+
+class GravityFormFormData {
+    private string $display_meta;
+    private string $title;
+    private string $updated;
+
+    public function __construct(string $display_meta, string $title, string $updated)
+    {
+        $this->display_meta = $display_meta;
+        $this->title = $title;
+        $this->updated = $updated;
+    }
+
+    public function getDisplayMeta(): string
+    {
+        return $this->display_meta;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getUpdated(): string
+    {
+        return $this->updated;
+    }
+}

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
@@ -5,7 +5,7 @@ namespace Smartling\DbAl\WordpressContentEntities;
 use Smartling\ContentTypes\ExternalContentGravityForms;
 use Smartling\WP\View\BulkSubmitScreenRow;
 
-class GravityFormsForm implements Entity {
+class GravityFormsForm extends EntityBase {
     private string $displayMeta;
     private int $id;
     private string $title;

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
@@ -7,16 +7,21 @@ use Smartling\WP\View\BulkSubmitScreenRow;
 
 class GravityFormsForm extends EntityBase {
     private string $displayMeta;
-    private int $id;
+    private ?int $id;
     private string $title;
     private ?string $updated;
 
-    public function __construct(string $displayMeta, int $id, string $title, ?string $updated)
+    public function __construct(string $displayMeta, ?int $id, string $title, ?string $updated)
     {
         $this->displayMeta = $displayMeta;
         $this->id = $id;
         $this->title = $title;
         $this->updated = $updated;
+    }
+
+    public function forInsert(): self
+    {
+        return new self($this->displayMeta, null, $this->title, $this->updated);
     }
 
     public function fromArray(array $array): self

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
@@ -3,6 +3,7 @@
 namespace Smartling\DbAl\WordpressContentEntities;
 
 use Smartling\ContentTypes\ExternalContentGravityForms;
+use Smartling\WP\View\BulkSubmitScreenRow;
 
 class GravityFormsForm implements Entity {
     private string $displayMeta;
@@ -48,15 +49,8 @@ class GravityFormsForm implements Entity {
         ];
     }
 
-    public function toBulkSubmitScreenRow(): array
+    public function toBulkSubmitScreenRow(): BulkSubmitScreenRow
     {
-        return [
-            'author' => '',
-            'id' => $this->id,
-            'status' => '',
-            'title' => $this->title,
-            'type' => ExternalContentGravityForms::CONTENT_TYPE,
-            'updated' => $this->updated,
-        ];
+        return new BulkSubmitScreenRow($this->id, $this->title, ExternalContentGravityForms::CONTENT_TYPE, updated: $this->updated);
     }
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
@@ -4,7 +4,7 @@ namespace Smartling\DbAl\WordpressContentEntities;
 
 use Smartling\ContentTypes\ExternalContentGravityForms;
 
-class GravityFormsForm implements EntityInterface {
+class GravityFormsForm implements Entity {
     private string $displayMeta;
     private int $id;
     private string $title;

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsForm.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Smartling\DbAl\WordpressContentEntities;
+
+use Smartling\ContentTypes\ExternalContentGravityForms;
+
+class GravityFormsForm implements EntityInterface {
+    private string $displayMeta;
+    private int $id;
+    private string $title;
+    private ?string $updated;
+
+    public function __construct(string $displayMeta, int $id, string $title, ?string $updated)
+    {
+        $this->displayMeta = $displayMeta;
+        $this->id = $id;
+        $this->title = $title;
+        $this->updated = $updated;
+    }
+
+    public function fromArray(array $array): self
+    {
+        return new self($array['displayMeta'], $array['id'], $array['title'], $array['updated']);
+    }
+
+    public function getDisplayMeta(): string
+    {
+        return $this->displayMeta;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'displayMeta' => $this->displayMeta,
+            'id' => $this->id,
+            'title' => $this->title,
+            'updated' => $this->updated,
+        ];
+    }
+
+    public function toBulkSubmitScreenRow(): array
+    {
+        return [
+            'author' => '',
+            'id' => $this->id,
+            'status' => '',
+            'title' => $this->title,
+            'type' => ExternalContentGravityForms::CONTENT_TYPE,
+            'updated' => $this->updated,
+        ];
+    }
+}

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
@@ -82,7 +82,7 @@ class GravityFormsFormHandler implements EntityHandler {
         return (int)$this->db->fetch("select count(*) cnt from $this->tableName", ARRAY_A)[0]['cnt'];
     }
 
-    public function set(EntityInterface $entity): int
+    public function set(Entity $entity): int
     {
         if (!$entity instanceof GravityFormsForm) {
             throw new \InvalidArgumentException("Handler only supports setting " . GravityFormsForm::class . ", " . get_class($entity) . " provided");

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
@@ -57,7 +57,7 @@ class GravityFormsFormHandler implements EntityHandler {
         }
         $meta = $meta[0];
 
-        return new GravityFormFormData($meta['display_meta'], $form['title'], $form['updated']);
+        return new GravityFormFormData($meta['display_meta'], $form['title'], $form['date_updated']);
     }
 
     public function getTotal(): int

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Smartling\DbAl\WordpressContentEntities;
+
+use JetBrains\PhpStorm\ArrayShape;
+use Smartling\DbAl\DB;
+use Smartling\Exception\EntityNotFoundException;
+use Smartling\Exception\SmartlingDbException;
+use Smartling\Helpers\QueryBuilder\Condition\Condition;
+use Smartling\Helpers\QueryBuilder\Condition\ConditionBlock;
+use Smartling\Helpers\QueryBuilder\Condition\ConditionBuilder;
+
+class GravityFormsFormHandler implements EntityHandler {
+    private DB $db;
+    private string $tableName;
+    private string $tableMetaName;
+
+    public function __construct(DB $db)
+    {
+        $this->db = $db;
+        $this->tableName = "{$this->db->getPrefix()}gf_form";
+        $this->tableMetaName = "{$this->db->getPrefix()}gf_form_meta";
+    }
+
+    public function get(int $id): GravityFormsForm
+    {
+        $data = $this->getFormData($id);
+        return new GravityFormsForm($this->getMeta($id)['display_meta'], $id, $data['title'], $data['date_updated']);
+    }
+
+    public function getAll(int $limit = 50, int $offset = 0, string $orderBy = '', string $order = '', string $searchString = ''): array
+    {
+        $condition = new ConditionBlock(ConditionBuilder::CONDITION_BLOCK_LEVEL_OPERATOR_AND);
+        if ($searchString !== '') {
+            $condition->addCondition(Condition::getCondition(ConditionBuilder::CONDITION_SIGN_EQ, 'title', [$searchString]));
+        }
+        $query = "select id, title, date_updated from $this->tableName";
+        if (count($condition->getConditions()) > 0) {
+            $query .= " where $condition";
+        }
+        $query .= " limit $offset, $limit";
+
+        return array_map(static function (array $item) {
+            return new GravityFormsForm('', $item['id'], $item['title'], $item['date_updated']);
+        }, $this->db->fetch($query, ARRAY_A));
+    }
+
+    #[ArrayShape([
+        'title' => 'string',
+        'date_updated' => 'string',
+    ])]
+    public function getFormData(int $id): array
+    {
+        $result = $this->db->fetchPrepared("select title, date_updated from $this->tableName where id = %s", $id);
+        if (count($result) !== 1) {
+            throw new EntityNotFoundException("Unable to get form data for Gravity Form $id");
+        }
+
+        return $result[0];
+    }
+
+    #[ArrayShape([
+        'display_meta' => 'string',
+    ])]
+    public function getMeta(int $id): array
+    {
+        $result = $this->db->fetchPrepared("select display_meta from $this->tableMetaName where form_id = %s", $id);
+        if (count($result) !== 1) {
+            throw new EntityNotFoundException("Unable to get meta for Gravity Form $id");
+        }
+
+        return $result[0];
+    }
+
+    public function getTitle(int $id): string
+    {
+        return $this->getFormData($id)['title'];
+    }
+
+    public function getTotal(): int
+    {
+        return (int)$this->db->fetch("select count(*) cnt from $this->tableName", ARRAY_A)[0]['cnt'];
+    }
+
+    public function set(EntityInterface $entity): int
+    {
+        if (!$entity instanceof GravityFormsForm) {
+            throw new \InvalidArgumentException("Handler only supports setting " . GravityFormsForm::class . ", " . get_class($entity) . " provided");
+        }
+        return $entity->getId() === null ? $this->insert($entity) : $this->update($entity);
+    }
+
+    private function insert(GravityFormsForm $entity): int
+    {
+        $id = $this->db->queryPrepared("insert into $this->tableName (title) values ('%s')", $entity->getTitle());
+        if (!is_int($id)) {
+            throw new SmartlingDbException("Unable to insert entity into gf_form table");
+        }
+        if ($this->db->queryPrepared("insert into $this->tableMetaName (display_meta, form_id) values (%s, %s)", $entity->getDisplayMeta(), $id) !== 1) {
+            $this->db->queryPrepared("delete from $this->tableName where id = %s", $id);
+            throw new SmartlingDbException("Failed to insert form meta for id {$entity->getId()}");
+        }
+        return $id;
+    }
+
+    private function update(GravityFormsForm $entity): int
+    {
+        if ($this->db->fetchPrepared("select count(*) cnt from $this->tableName where id = %s", $entity->getId())[0]['cnt'] !== "1" ||
+            $this->db->fetchPrepared("select count(*) cnt from $this->tableMetaName where form_id = %s", $entity->getId())[0]['cnt'] !== "1") {
+            throw new SmartlingDbException("Failed to update form table by id {$entity->getId()}");
+        }
+        $this->db->queryPrepared("update {$this->db->getPrefix()}gf_form set title = '%s' where id = %s", $entity->getTitle(), $entity->getId());
+        $this->db->queryPrepared("update {$this->db->getPrefix()}gf_form_meta set display_meta = %s where form_id = %s", $entity->getDisplayMeta(), $entity->getId());
+        return $entity->getId();
+    }
+}

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
@@ -22,7 +22,7 @@ class GravityFormsFormHandler implements EntityHandler {
         $this->tableMetaName = $db->completeTableName('gf_form_meta');
     }
 
-    public function get(int $id): GravityFormsForm
+    public function get(mixed $id): GravityFormsForm
     {
         $data = $this->getFormData($id);
         return new GravityFormsForm($this->getMeta($id)['display_meta'], $id, $data['title'], $data['date_updated']);
@@ -70,11 +70,6 @@ class GravityFormsFormHandler implements EntityHandler {
         }
 
         return $result[0];
-    }
-
-    public function getTitle(int $id): string
-    {
-        return $this->getFormData($id)['title'];
     }
 
     public function getTotal(): int

--- a/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/GravityFormsFormHandler.php
@@ -3,7 +3,7 @@
 namespace Smartling\DbAl\WordpressContentEntities;
 
 use JetBrains\PhpStorm\ArrayShape;
-use Smartling\DbAl\DB;
+use Smartling\DbAl\SmartlingToCMSDatabaseAccessWrapperInterface;
 use Smartling\Exception\EntityNotFoundException;
 use Smartling\Exception\SmartlingDbException;
 use Smartling\Helpers\QueryBuilder\Condition\Condition;
@@ -11,15 +11,15 @@ use Smartling\Helpers\QueryBuilder\Condition\ConditionBlock;
 use Smartling\Helpers\QueryBuilder\Condition\ConditionBuilder;
 
 class GravityFormsFormHandler implements EntityHandler {
-    private DB $db;
+    private SmartlingToCMSDatabaseAccessWrapperInterface $db;
     private string $tableName;
     private string $tableMetaName;
 
-    public function __construct(DB $db)
+    public function __construct(SmartlingToCMSDatabaseAccessWrapperInterface $db)
     {
         $this->db = $db;
-        $this->tableName = "{$this->db->getPrefix()}gf_form";
-        $this->tableMetaName = "{$this->db->getPrefix()}gf_form_meta";
+        $this->tableName = $db->completeTableName('gf_form');
+        $this->tableMetaName = $db->completeTableName('gf_form_meta');
     }
 
     public function get(int $id): GravityFormsForm

--- a/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
@@ -7,6 +7,7 @@ use Smartling\Helpers\RawDbQueryHelper;
 use Smartling\Helpers\WordpressFunctionProxyHelper;
 use Smartling\Helpers\WordpressUserHelper;
 use Smartling\Services\GlobalSettingsManager;
+use Smartling\WP\View\BulkSubmitScreenRow;
 
 /**
  * @method setPostContent($string)
@@ -377,18 +378,16 @@ class PostEntityStd extends EntityAbstract implements EntityWithPostStatus, Enti
 
     /**
      * Converts instance of EntityAbstract to array to be used for BulkSubmit screen
-     * @return array
      */
-    public function toBulkSubmitScreenRow(): array
+    public function toBulkSubmitScreenRow(): BulkSubmitScreenRow
     {
-        return [
-            'id'      => $this->getPK(),
-            'title'   => $this->post_title,
-            'type'    => $this->post_type,
-            'author'  => WordpressUserHelper::getUserLoginById((int)$this->post_author),
-            'status'  => $this->post_status,
-            'locales' => null,
-            'updated' => $this->post_date,
-        ];
+        return new BulkSubmitScreenRow($this->getId(),
+            $this->post_title,
+            $this->post_type,
+            WordpressUserHelper::getUserLoginById($this->post_author),
+            null,
+            $this->post_status,
+            $this->post_date,
+        );
     }
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
@@ -36,9 +36,8 @@ use Smartling\Services\GlobalSettingsManager;
  * @property string       $hash
  * @package Smartling\DbAl\WordpressContentEntities
  */
-class PostEntityStd extends EntityAbstract
+class PostEntityStd extends EntityAbstract implements EntityWithPostStatus, EntityWithMetadata
 {
-
     /**
      * Standard 'post' content-type fields
      * @var array
@@ -98,6 +97,11 @@ class PostEntityStd extends EntityAbstract
     public function getContentTypeProperty()
     {
         return 'post_type';
+    }
+
+    public function getId(): ?int
+    {
+        return $this->ID;
     }
 
     /**
@@ -273,7 +277,7 @@ class PostEntityStd extends EntityAbstract
      * @param string $orderBy
      * @param string $order
      * @param string $searchString
-     * @return PostEntityStd[]
+     * @return PostEntityStdWithPostStatus[]
      */
     public function getAll($limit = 0, $offset = 0, $orderBy = 'date', $order = 'DESC', $searchString = '')
     {
@@ -337,7 +341,7 @@ class PostEntityStd extends EntityAbstract
         return $total;
     }
 
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->post_title;
     }
@@ -414,12 +418,12 @@ class PostEntityStd extends EntityAbstract
         }
     }
 
-    public function translationDrafted()
+    public function translationDrafted(): void
     {
         $this->post_status = 'draft';
     }
 
-    public function translationCompleted()
+    public function translationCompleted(): void
     {
         $this->post_status = 'publish';
     }
@@ -428,7 +432,7 @@ class PostEntityStd extends EntityAbstract
      * Converts instance of EntityAbstract to array to be used for BulkSubmit screen
      * @return array
      */
-    public function toBulkSubmitScreenRow()
+    public function toBulkSubmitScreenRow(): array
     {
         return [
             'id'      => $this->getPK(),

--- a/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/PostEntityStd.php
@@ -277,7 +277,7 @@ class PostEntityStd extends EntityAbstract implements EntityWithPostStatus, Enti
      * @param string $orderBy
      * @param string $order
      * @param string $searchString
-     * @return PostEntityStdWithPostStatus[]
+     * @return self[]
      */
     public function getAll($limit = 0, $offset = 0, $orderBy = 'date', $order = 'DESC', $searchString = '')
     {

--- a/inc/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStd.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStd.php
@@ -20,7 +20,7 @@ use Smartling\Helpers\WordpressFunctionProxyHelper;
  * @property int    $parent
  * @property int    $count
  */
-class TaxonomyEntityStd extends EntityAbstract
+class TaxonomyEntityStd extends EntityAbstract implements EntityWithMetadata
 {
     /**
      * Standard taxonomy fields
@@ -128,10 +128,12 @@ class TaxonomyEntityStd extends EntityAbstract
         return 'taxonomy';
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getTitle()
+    public function getId(): ?int
+    {
+        return $this->term_id;
+    }
+
+    public function getTitle(): string
     {
         return $this->name;
     }
@@ -241,7 +243,6 @@ class TaxonomyEntityStd extends EntityAbstract
 
     /**
      * @param EntityAbstract $entity
-     *
      * @return array
      * @throws SmartlingDbException
      */
@@ -386,7 +387,7 @@ class TaxonomyEntityStd extends EntityAbstract
      * Converts instance of EntityAbstract to array to be used for BulkSubmit screen
      * @return array
      */
-    public function toBulkSubmitScreenRow()
+    public function toBulkSubmitScreenRow(): array
     {
         return [
             'id'      => $this->term_id,

--- a/inc/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStd.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStd.php
@@ -5,6 +5,7 @@ namespace Smartling\DbAl\WordpressContentEntities;
 use Smartling\Exception\EntityNotFoundException;
 use Smartling\Exception\SmartlingDbException;
 use Smartling\Helpers\WordpressFunctionProxyHelper;
+use Smartling\WP\View\BulkSubmitScreenRow;
 
 /**
  * @property int    $term_id
@@ -313,16 +314,8 @@ class TaxonomyEntityStd extends EntityAbstract implements EntityWithMetadata
     /**
      * Converts instance of EntityAbstract to array to be used for BulkSubmit screen
      */
-    public function toBulkSubmitScreenRow(): array
+    public function toBulkSubmitScreenRow(): BulkSubmitScreenRow
     {
-        return [
-            'id'      => $this->term_id,
-            'title'   => $this->name,
-            'type'    => $this->taxonomy,
-            'author'  => null,
-            'status'  => null,
-            'locales' => null,
-            'updated' => null,
-        ];
+        return new BulkSubmitScreenRow($this->term_id, $this->name, $this->taxonomy);
     }
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStd.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/TaxonomyEntityStd.php
@@ -300,10 +300,12 @@ class TaxonomyEntityStd extends EntityAbstract implements EntityWithMetadata
         ];
     }
 
-    public function cleanFields(mixed $value = null): void
+    public function forInsert(): static
     {
-        parent::cleanFields($value);
-        $this->term_taxonomy_id = $value;
+        $result = parent::forInsert();
+        $result->term_taxonomy_id = null;
+
+        return $result;
     }
 
     public function getPrimaryFieldName(): string

--- a/inc/Smartling/DbAl/WordpressContentEntities/VirtualEntityAbstract.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/VirtualEntityAbstract.php
@@ -2,17 +2,25 @@
 
 namespace Smartling\DbAl\WordpressContentEntities;
 
-/**
- * Class VirtualEntityAbstract
- * @package Smartling\DbAl\WordpressContentEntities
- */
 abstract class VirtualEntityAbstract extends EntityAbstract
 {
-    /**
-     * @return string
-     */
-    public function getContentTypeProperty()
+    protected array $fields;
+
+    public function getContentTypeProperty(): string
     {
         return '';
+    }
+
+    protected function getFieldNameByMethodName($method): string
+    {
+        $way = substr($method, 0, 3);
+        $possibleField = lcfirst(substr($method, 3));
+        if (in_array($way, ['set', 'get']) && in_array($possibleField, $this->fields, true)) {
+            return $possibleField;
+        }
+
+        $message = vsprintf('Method %s not found in %s', [$method, __CLASS__]);
+        $this->getLogger()->error($message);
+        throw new \BadMethodCallException($message);
     }
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
@@ -5,6 +5,7 @@ namespace Smartling\DbAl\WordpressContentEntities;
 use Smartling\Helpers\StringHelper;
 use Smartling\Helpers\ThemeSidebarHelper;
 use Smartling\Helpers\WidgetHelper;
+use Smartling\WP\View\BulkSubmitScreenRow;
 
 /**
  * @property int    $id                 Unique id
@@ -196,19 +197,11 @@ class WidgetEntity extends VirtualEntityAbstract
 
     /**
      * Converts instance of EntityAbstract to array to be used for BulkSubmit screen
-     * @return array
      */
-    public function toBulkSubmitScreenRow(): array
+    public function toBulkSubmitScreenRow(): BulkSubmitScreenRow
     {
-        return [
-            'id'      => $this->getId(),
-            'title'   => '"' . $this->getTitle() . '" on ' . ThemeSidebarHelper::getSideBarLabel($this->getBar()) .
-                         '(position ' . $this->getBarPosition() . ')',
-            'type'    => $this->getType(),
-            'author'  => $this->getIndex(),
-            'status'  => null,
-            'locales' => null,
-            'updated' => null,
-        ];
+        return new BulkSubmitScreenRow($this->getId(),
+            sprintf('"%s" on %s (position %d)', $this->getTitle(), ThemeSidebarHelper::getSideBarLabel($this->getBar()), $this->getBarPosition()), $this->getType(),
+        );
     }
 }

--- a/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
@@ -7,7 +7,6 @@ use Smartling\Helpers\ThemeSidebarHelper;
 use Smartling\Helpers\WidgetHelper;
 
 /**
- * Class WidgetEntity
  * @property int    $id                 Unique id
  * @property string $widgetType         widget type
  * @property int    $index              Widget descriptor index (Wordpress internal)
@@ -20,20 +19,15 @@ use Smartling\Helpers\WidgetHelper;
  * @method string   getBar()            Returns bar related to index
  * @method int      getBarPosition()    Returns Widget position in the bar
  * @method array setSettings(array $settings)
- * @package Smartling\DbAl\WordpressContentEntities
  */
 class WidgetEntity extends VirtualEntityAbstract
 {
     /**
      * @var WidgetHelper[] All widgets of current theme.
      */
-    protected $map = [];
+    protected array $map = [];
 
-    /**
-     * Standard 'post' content-type fields
-     * @var array
-     */
-    protected $fields = [
+    protected array $fields = [
         'id',
         'widgetType',
         'index',
@@ -42,9 +36,6 @@ class WidgetEntity extends VirtualEntityAbstract
         'settings',
     ];
 
-    /**
-     * @inheritdoc
-     */
     public function __construct($type, array $related = [])
     {
         parent::__construct();
@@ -62,26 +53,6 @@ class WidgetEntity extends VirtualEntityAbstract
         $this->setRelatedTypes($related);
     }
 
-    /**
-     * @inheritdoc
-     */
-    protected function getFieldNameByMethodName($method)
-    {
-
-        $way = substr($method, 0, 3);
-
-        $possibleField = lcfirst(substr($method, 3));
-
-        if (in_array($way, ['set', 'get']) && in_array($possibleField, $this->fields, true)) {
-            return $possibleField;
-        }
-
-        $message = vsprintf('Method %s not found in %s', [$method, __CLASS__]);
-        $this->getLogger()
-            ->error($message);
-        throw new \BadMethodCallException($message);
-    }
-
     public function getId(): ?int
     {
         return $this->id;
@@ -96,32 +67,18 @@ class WidgetEntity extends VirtualEntityAbstract
             : $title;
     }
 
-    /**
-     * Loads the entity from database
-     * @param $guid
-     * @return EntityAbstract
-     */
-    public function get($guid)
+    public function get(mixed $id): self
     {
         $this->buildMap();
 
-        if (array_key_exists($guid, $this->map)) {
-            return $this->resultToEntity($this->map[$guid]->toArray());
+        if (array_key_exists($id, $this->map)) {
+            return $this->resultToEntity($this->map[$id]->toArray());
         }
 
-        $this->entityNotFound('theme_widget', $guid);
+        $this->entityNotFound('theme_widget', $id);
     }
 
-    /**
-     * @param string $tagName
-     * @param string $tagValue
-     * @param bool   $unique
-     */
-    public function setMetaTag($tagName, $tagValue, $unique = true): void
-    {
-    }
-
-    protected function buildMap()
+    protected function buildMap(): void
     {
         $this->map = [];
 
@@ -154,14 +111,9 @@ class WidgetEntity extends VirtualEntityAbstract
     }
 
     /**
-     * @param int $limit
-     * @param int $offset
-     * @param string $orderBy
-     * @param string $order
-     * @param string $searchString
      * @return WidgetEntity[]
      */
-    public function getAll($limit = 0, $offset = 0, $orderBy = '', $order = '', $searchString = '')
+    public function getAll(int $limit = 0, int $offset = 0, string $orderBy = '', string $order = '', string $searchString = ''): array
     {
         $this->buildMap();
         $collection = [];
@@ -173,23 +125,14 @@ class WidgetEntity extends VirtualEntityAbstract
         return array_slice($collection, $offset, $limit);
     }
 
-
-    /**
-     * @return int
-     */
-    public function getTotal()
+    public function getTotal(): int
     {
         $this->buildMap();
 
         return (count($this->map));
     }
 
-    /**
-     * @param WidgetEntity $entity
-     *
-     * @return array
-     */
-    private function instanceToArray(WidgetEntity $entity)
+    private function instanceToArray(WidgetEntity $entity): array
     {
         return [
             'widgetType'  => $entity->getWidgetType(),
@@ -200,19 +143,19 @@ class WidgetEntity extends VirtualEntityAbstract
         ];
     }
 
-    /**
-     * @param WidgetEntity $entity
-     *
-     * @return WidgetHelper
-     */
-    private function getWidgetHelperInstance(WidgetEntity $entity)
+    public function toArray(): array
+    {
+        return $this->instanceToArray($this);
+    }
+
+    private function getWidgetHelperInstance(self $entity): WidgetHelper
     {
         if (
-            (int)$entity->getPK() > 0
+            $entity->getPK() > 0
             && !array_key_exists(WidgetHelper::SMARTLING_IDENTITY_FIELD_NAME, $entity->getSettings())
         ) {
             $settings = $entity->getSettings();
-            $settings[WidgetHelper::SMARTLING_IDENTITY_FIELD_NAME] = (int)$entity->getPK();
+            $settings[WidgetHelper::SMARTLING_IDENTITY_FIELD_NAME] = $entity->getPK();
             $entity->setSettings($settings);
         }
 
@@ -221,10 +164,10 @@ class WidgetEntity extends VirtualEntityAbstract
 
     /**
      * Stores entity to database
-     * @param EntityAbstract $entity
-     * @return mixed
+     * @param Entity $entity
+     * @return int
      */
-    public function set(EntityAbstract $entity = null)
+    public function set(Entity $entity): int
     {
         if (!$entity instanceof self) {
             throw new \InvalidArgumentException("WidgetEntity->set() must be called with WidgetEntity");
@@ -238,7 +181,7 @@ class WidgetEntity extends VirtualEntityAbstract
     /**
      * @return array
      */
-    protected function getNonCloneableFields()
+    protected function getNonCloneableFields(): array
     {
         return [$this->getPrimaryFieldName()];
     }
@@ -246,7 +189,7 @@ class WidgetEntity extends VirtualEntityAbstract
     /**
      * @return string
      */
-    public function getPrimaryFieldName()
+    public function getPrimaryFieldName(): string
     {
         return 'id';
     }

--- a/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
+++ b/inc/Smartling/DbAl/WordpressContentEntities/WidgetEntity.php
@@ -14,7 +14,6 @@ use Smartling\Helpers\WidgetHelper;
  * @property string $bar                Sidebar Id
  * @property int    $barPosition        Widget Position in Sidebar
  * @property array  $settings           Widget settings
- * @method int getId()
  * @method array    getSettings()       Returns settings key => value array
  * @method string   getWidgetType()     Returns Wordpress Widget type
  * @method int      getIndex()          Returns Widget index
@@ -83,18 +82,14 @@ class WidgetEntity extends VirtualEntityAbstract
         throw new \BadMethodCallException($message);
     }
 
-    public function getMetadata(): array
+    public function getId(): ?int
     {
-        return [];
+        return $this->id;
     }
 
-    /**
-     * @return string
-     */
-    public function getTitle()
+    public function getTitle(): string
     {
-        $title = array_key_exists('title', $this->getSettings())
-            ? $this->getSettings()['title'] : null;
+        $title = $this->getSettings()['title'] ?? null;
 
         return StringHelper::isNullOrEmpty($title)
             ? WidgetHelper::getWpWidget($this->getWidgetType())->name
@@ -103,9 +98,7 @@ class WidgetEntity extends VirtualEntityAbstract
 
     /**
      * Loads the entity from database
-     *
      * @param $guid
-     *
      * @return EntityAbstract
      */
     public function get($guid)
@@ -228,9 +221,7 @@ class WidgetEntity extends VirtualEntityAbstract
 
     /**
      * Stores entity to database
-     *
      * @param EntityAbstract $entity
-     *
      * @return mixed
      */
     public function set(EntityAbstract $entity = null)
@@ -264,7 +255,7 @@ class WidgetEntity extends VirtualEntityAbstract
      * Converts instance of EntityAbstract to array to be used for BulkSubmit screen
      * @return array
      */
-    public function toBulkSubmitScreenRow()
+    public function toBulkSubmitScreenRow(): array
     {
         return [
             'id'      => $this->getId(),

--- a/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
+++ b/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
@@ -12,29 +12,11 @@ use Smartling\Helpers\QueryBuilder\QueryBuilder;
 
 /**
  * @method string getName
+ * @property int $id
  */
 class AcfOptionEntity extends VirtualEntityAbstract
 {
-    /**
-     * @var SmartlingToCMSDatabaseAccessWrapperInterface
-     */
-    private $dbal;
-
-    /**
-     * @return SmartlingToCMSDatabaseAccessWrapperInterface
-     */
-    public function getDbal()
-    {
-        return $this->dbal;
-    }
-
-    /**
-     * @param SmartlingToCMSDatabaseAccessWrapperInterface $dbal
-     */
-    public function setDbal($dbal)
-    {
-        $this->dbal = $dbal;
-    }
+    private SmartlingToCMSDatabaseAccessWrapperInterface $dbal;
 
     /**
      * Standard 'option' content-type fields
@@ -51,15 +33,16 @@ class AcfOptionEntity extends VirtualEntityAbstract
     /**
      * @inheritdoc
      */
-    public function __construct()
+    public function __construct(SmartlingToCMSDatabaseAccessWrapperInterface $dbal)
     {
         parent::__construct();
-        $this->setType(ContentTypeAcfOption::WP_CONTENT_TYPE);
+        $this->dbal = $dbal;
+        $this->type = ContentTypeAcfOption::WP_CONTENT_TYPE;
         $this->hashAffectingFields = array_merge($this->hashAffectingFields, ['name', 'value']);
         $this->setEntityFields($this->fields);
     }
 
-    protected function getFieldNameByMethodName($method)
+    protected function getFieldNameByMethodName($method): string
     {
         $way = substr($method, 0, 3);
         $possibleField = lcfirst(substr($method, 3));
@@ -77,7 +60,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
         return $this->getName();
     }
 
-    public function get($guid)
+    public function get($guid): self
     {
         $this->buildMap();
 
@@ -88,16 +71,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
         return $this->resultToEntity($this->map[$guid]->toArray());
     }
 
-    /**
-     * @param string $tagName
-     * @param string $tagValue
-     * @param bool   $unique
-     */
-    public function setMetaTag($tagName, $tagValue, $unique = true): void
-    {
-    }
-
-    private function getOptionNames()
+    private function getOptionNames(): array
     {
         $block = ConditionBlock::getConditionBlock();
         $condition = Condition::getCondition(
@@ -107,18 +81,18 @@ class AcfOptionEntity extends VirtualEntityAbstract
         );
         $block->addCondition($condition);
         $query = QueryBuilder::buildSelectQuery(
-            $this->getDbal()->completeTableName('options'),
+            $this->dbal->completeTableName('options'),
             ['option_name'],
             $block
         );
 
-        return $this->getDbal()->fetch($query, \ARRAY_A);
+        return $this->dbal->fetch($query, \ARRAY_A);
     }
 
     /**
      * Reads all options and generates InMemory map to emulate get($guid)
      */
-    private function buildMap()
+    private function buildMap(): void
     {
         $raw_options = $this->getOptionNames();
         $this->map = [];
@@ -139,7 +113,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
      * @param string $searchString
      * @return AcfOptionEntity[]
      */
-    public function getAll($limit = 0, $offset = 0, $orderBy = '', $order = '', $searchString = '')
+    public function getAll($limit = 0, $offset = 0, $orderBy = '', $order = '', $searchString = ''): array
     {
         $this->buildMap();
         $collection = [];
@@ -152,10 +126,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
         return array_slice($collection, $offset, $limit);
     }
 
-    /**
-     * @return int
-     */
-    public function getTotal()
+    public function getTotal(): int
     {
         $this->buildMap();
 
@@ -164,10 +135,8 @@ class AcfOptionEntity extends VirtualEntityAbstract
 
     /**
      * Stores entity to database
-     * @param EntityAbstract $entity
-     * @return mixed
      */
-    public function set(EntityAbstract $entity = null)
+    public function set(EntityAbstract $entity = null): ?int
     {
         if ($entity === null) {
             throw new \InvalidArgumentException(self::class . "->set() must be called with " . self::class);
@@ -178,37 +147,24 @@ class AcfOptionEntity extends VirtualEntityAbstract
         return $acfOptionHelper->getPk();
     }
 
-    /**
-     * @return array
-     */
-    protected function getNonCloneableFields()
+    protected function getNonCloneableFields(): array
     {
         return [$this->getPrimaryFieldName()];
     }
 
-    /**
-     * @return string
-     */
-    public function getPrimaryFieldName()
+    public function getPrimaryFieldName(): string
     {
         return 'id';
     }
 
-    public function toArray($skipNameField = true)
+    public function toArray(): array
     {
         $state = parent::toArray();
-
-        if (true === $skipNameField) {
-            unset($state['name']);
-        }
+        unset($state['name']);
 
         return $state;
     }
 
-    /**
-     * Converts instance of EntityAbstract to array to be used for BulkSubmit screen
-     * @return array
-     */
     public function toBulkSubmitScreenRow(): array
     {
         return [
@@ -221,5 +177,10 @@ class AcfOptionEntity extends VirtualEntityAbstract
             'updated' => null,
         ];
 
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
     }
 }

--- a/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
+++ b/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
@@ -4,12 +4,12 @@ namespace Smartling\Extensions\AcfOptionPages;
 
 use Smartling\DbAl\SmartlingToCMSDatabaseAccessWrapperInterface;
 use Smartling\DbAl\WordpressContentEntities\Entity;
-use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
 use Smartling\DbAl\WordpressContentEntities\VirtualEntityAbstract;
 use Smartling\Helpers\QueryBuilder\Condition\Condition;
 use Smartling\Helpers\QueryBuilder\Condition\ConditionBlock;
 use Smartling\Helpers\QueryBuilder\Condition\ConditionBuilder;
 use Smartling\Helpers\QueryBuilder\QueryBuilder;
+use Smartling\WP\View\BulkSubmitScreenRow;
 
 /**
  * @method string getName
@@ -149,18 +149,9 @@ class AcfOptionEntity extends VirtualEntityAbstract
         return $state;
     }
 
-    public function toBulkSubmitScreenRow(): array
+    public function toBulkSubmitScreenRow(): BulkSubmitScreenRow
     {
-        return [
-            'id'      => $this->getId(),
-            'title'   => $this->getTitle(),
-            'type'    => $this->getType(),
-            'author'  => null,
-            'status'  => null,
-            'locales' => null,
-            'updated' => null,
-        ];
-
+        return new BulkSubmitScreenRow($this->getId(), $this->getTitle(), $this->getType());
     }
 
     public function getId(): ?int

--- a/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
+++ b/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
@@ -72,15 +72,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
         throw new \BadMethodCallException($message);
     }
 
-    public function getMetadata(): array
-    {
-        return [];
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->getName();
     }
@@ -172,9 +164,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
 
     /**
      * Stores entity to database
-     *
      * @param EntityAbstract $entity
-     *
      * @return mixed
      */
     public function set(EntityAbstract $entity = null)
@@ -219,7 +209,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
      * Converts instance of EntityAbstract to array to be used for BulkSubmit screen
      * @return array
      */
-    public function toBulkSubmitScreenRow()
+    public function toBulkSubmitScreenRow(): array
     {
         return [
             'id'      => $this->getId(),

--- a/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
+++ b/inc/Smartling/Extensions/AcfOptionPages/AcfOptionEntity.php
@@ -3,6 +3,7 @@
 namespace Smartling\Extensions\AcfOptionPages;
 
 use Smartling\DbAl\SmartlingToCMSDatabaseAccessWrapperInterface;
+use Smartling\DbAl\WordpressContentEntities\Entity;
 use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
 use Smartling\DbAl\WordpressContentEntities\VirtualEntityAbstract;
 use Smartling\Helpers\QueryBuilder\Condition\Condition;
@@ -20,19 +21,15 @@ class AcfOptionEntity extends VirtualEntityAbstract
 
     /**
      * Standard 'option' content-type fields
-     * @var array
      */
-    protected $fields = [
+    protected array $fields = [
         'id',
         'name',
         'value',
     ];
 
-    private $map = [];
+    private array $map = [];
 
-    /**
-     * @inheritdoc
-     */
     public function __construct(SmartlingToCMSDatabaseAccessWrapperInterface $dbal)
     {
         parent::__construct();
@@ -42,33 +39,20 @@ class AcfOptionEntity extends VirtualEntityAbstract
         $this->setEntityFields($this->fields);
     }
 
-    protected function getFieldNameByMethodName($method): string
-    {
-        $way = substr($method, 0, 3);
-        $possibleField = lcfirst(substr($method, 3));
-        if (in_array($way, ['set', 'get']) && in_array($possibleField, $this->fields, true)) {
-            return $possibleField;
-        }
-
-        $message = vsprintf('Method %s not found in %s', [$method, __CLASS__]);
-        $this->getLogger()->error($message);
-        throw new \BadMethodCallException($message);
-    }
-
     public function getTitle(): string
     {
         return $this->getName();
     }
 
-    public function get($guid): self
+    public function get(mixed $id): self
     {
         $this->buildMap();
 
-        if (!array_key_exists($guid, $this->map)) {
-            $this->entityNotFound(ContentTypeAcfOption::WP_CONTENT_TYPE, $guid);
+        if (!array_key_exists($id, $this->map)) {
+            $this->entityNotFound(ContentTypeAcfOption::WP_CONTENT_TYPE, $id);
         }
 
-        return $this->resultToEntity($this->map[$guid]->toArray());
+        return $this->resultToEntity($this->map[$id]->toArray());
     }
 
     private function getOptionNames(): array
@@ -113,7 +97,7 @@ class AcfOptionEntity extends VirtualEntityAbstract
      * @param string $searchString
      * @return AcfOptionEntity[]
      */
-    public function getAll($limit = 0, $offset = 0, $orderBy = '', $order = '', $searchString = ''): array
+    public function getAll(int $limit = 0, int $offset = 0, string $orderBy = '', string $order = '', string $searchString = ''): array
     {
         $this->buildMap();
         $collection = [];
@@ -136,9 +120,9 @@ class AcfOptionEntity extends VirtualEntityAbstract
     /**
      * Stores entity to database
      */
-    public function set(EntityAbstract $entity = null): ?int
+    public function set(Entity $entity): int
     {
-        if ($entity === null) {
+        if (!$entity instanceof self) {
             throw new \InvalidArgumentException(self::class . "->set() must be called with " . self::class);
         }
         $acfOptionHelper = AcfOptionHelper::fromArray($entity->toArray());

--- a/inc/Smartling/Extensions/AcfOptionPages/ContentTypeAcfOption.php
+++ b/inc/Smartling/Extensions/AcfOptionPages/ContentTypeAcfOption.php
@@ -4,6 +4,7 @@ namespace Smartling\Extensions\AcfOptionPages;
 
 use Smartling\ContentTypes\ContentTypeAbstract;
 use Smartling\ContentTypes\ContentTypeManager;
+use Smartling\Exception\SmartlingConfigException;
 use Smartling\Vendor\Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ContentTypeAcfOption extends ContentTypeAbstract
@@ -20,61 +21,32 @@ class ContentTypeAcfOption extends ContentTypeAbstract
         parent::__construct($di);
 
         $this->registerIOWrapper();
-        $this->registerWidgetHandler();
-        $this->registerFilters();
     }
 
-    /**
-     * @param ContainerBuilder $di
-     * @param string           $manager
-     */
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
+    public static function register(ContainerBuilder $di, string $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);
-        /**
-         * @var ContentTypeManager $mgr
-         */
+        if (!$mgr instanceof ContentTypeManager) {
+            throw new SmartlingConfigException(ContentTypeManager::class . ' expected');
+        }
         $mgr->addDescriptor($descriptor);
     }
 
-    /**
-     * Display name of content type, e.g.: Post
-     * @return string
-     */
     public function getLabel(): string
     {
         return __('ACF Options Page');
     }
 
-    /**
-     * Handler to register IO Wrapper
-     * @return void
-     */
-    public function registerIOWrapper()
+    public function registerIOWrapper(): void
     {
         $di = $this->getContainerBuilder();
         $wrapperId = 'wrapper.entity.' . $this->getSystemName();
-        $definition = $di->register($wrapperId, 'Smartling\Extensions\AcfOptionPages\AcfOptionEntity');
+        $definition = $di->register($wrapperId, AcfOptionEntity::class);
         $definition
-            ->addMethodCall('setDbal', [$di->getDefinition('site.db')]);
+            ->addArgument($di->getDefinition('site.db'));
 
         $di->get('factory.contentIO')->registerHandler($this->getSystemName(), $di->get($wrapperId));
-    }
-
-    /**
-     * Handler to register Widget (Edit Screen)
-     * @return void
-     */
-    public function registerWidgetHandler()
-    {
-    }
-
-    /**
-     * @return void
-     */
-    public function registerFilters()
-    {
     }
 
     /**

--- a/inc/Smartling/Extensions/AcfOptionPages/ContentTypeAcfOption.php
+++ b/inc/Smartling/Extensions/AcfOptionPages/ContentTypeAcfOption.php
@@ -6,31 +6,15 @@ use Smartling\ContentTypes\ContentTypeAbstract;
 use Smartling\ContentTypes\ContentTypeManager;
 use Smartling\Vendor\Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Class ContentTypeAcfOption
- */
 class ContentTypeAcfOption extends ContentTypeAbstract
 {
+    public const WP_CONTENT_TYPE = 'acf_options';
 
-    /**
-     * The system name of Wordpress content type to make references safe.
-     */
-    const WP_CONTENT_TYPE = 'acf_options';
-
-    /**
-     * Wordpress name of content-type, e.g.: post, page, post-tag
-     * @return string
-     */
-    public function getSystemName()
+    public function getSystemName(): string
     {
         return static::WP_CONTENT_TYPE;
     }
 
-    /**
-     * ContentTypeAcfOption constructor.
-     *
-     * @param ContainerBuilder $di
-     */
     public function __construct(ContainerBuilder $di)
     {
         parent::__construct($di);
@@ -44,7 +28,7 @@ class ContentTypeAcfOption extends ContentTypeAbstract
      * @param ContainerBuilder $di
      * @param string           $manager
      */
-    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager')
+    public static function register(ContainerBuilder $di, $manager = 'content-type-descriptor-manager'): void
     {
         $descriptor = new static($di);
         $mgr = $di->get($manager);
@@ -58,23 +42,9 @@ class ContentTypeAcfOption extends ContentTypeAbstract
      * Display name of content type, e.g.: Post
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return __('ACF Options Page');
-    }
-
-    /**
-     * @return array [
-     *  'submissionBoard'   => true|false,
-     *  'bulkSubmit'        => true|false
-     * ]
-     */
-    public function getVisibility()
-    {
-        return [
-            'submissionBoard' => true,
-            'bulkSubmit'      => true,
-        ];
     }
 
     /**
@@ -111,12 +81,12 @@ class ContentTypeAcfOption extends ContentTypeAbstract
      * Base type can be 'post' or 'term' used for Multilingual Press plugin.
      * @return string
      */
-    public function getBaseType()
+    public function getBaseType(): string
     {
         return 'virtual';
     }
 
-    public function isVirtual()
+    public function isVirtual(): bool
     {
         return true;
     }

--- a/inc/Smartling/Extensions/ExtensionLoader.php
+++ b/inc/Smartling/Extensions/ExtensionLoader.php
@@ -2,35 +2,27 @@
 
 namespace Smartling\Extensions;
 
+use Smartling\Exception\SmartlingConfigException;
 use Smartling\Processors\SmartlingFactoryAbstract;
 
-/**
- * Class ExtensionLoader
- *
- * @package Smartling\Extensions
- */
 class ExtensionLoader extends SmartlingFactoryAbstract
 {
-
-    public function registerExtension(ExtensionInterface $extension)
+    public function registerExtension(ExtensionInterface $extension): void
     {
         $this->registerHandler($extension->getName(), $extension);
     }
 
-    public function runExtensions()
+    /** @noinspection PhpUnused used in Bootstrap */
+    public function runExtensions(): void
     {
-        $extenstions = $this->getCollection();
-        if (0 < count($extenstions)) {
-            foreach ($extenstions as $name => $extension) {
-                try {
-                    /**
-                     * @var ExtensionInterface $extension
-                     */
-                    $extension->register();
-                } catch (\Exception $e) {
-                    $this->getLogger()
-                         ->error('Failed initialization of ' . $name . ' extension.');
+        foreach ($this->collection as $name => $extension) {
+            try {
+                if (!$extension instanceof ExtensionInterface) {
+                    throw new SmartlingConfigException(self::class . ' expects a collection of ' . ExtensionInterface::class);
                 }
+                $extension->register();
+            } catch (\Exception $e) {
+                $this->getLogger()->error("Failed initialization of $name extension: {$e->getMessage()}");
             }
         }
     }

--- a/inc/Smartling/Helpers/ContentHelper.php
+++ b/inc/Smartling/Helpers/ContentHelper.php
@@ -3,7 +3,7 @@
 namespace Smartling\Helpers;
 
 use Exception;
-use Smartling\DbAl\WordpressContentEntities\EntityInterface;
+use Smartling\DbAl\WordpressContentEntities\Entity;
 use Smartling\DbAl\WordpressContentEntities\EntityHandler;
 use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
 use Smartling\DbAl\WordpressContentEntities\EntityWithMetadata;
@@ -144,7 +144,7 @@ class ContentHelper
         return $return;
     }
 
-    public function readSourceContent(SubmissionEntity $submission): EntityInterface
+    public function readSourceContent(SubmissionEntity $submission): Entity
     {
         if (false === ($cached = $this->getRuntimeCache()->get($submission->getId(), 'sourceContent'))) {
             $wrapper = $this->getWrapper($submission->getContentType());
@@ -159,7 +159,7 @@ class ContentHelper
         return $clone;
     }
 
-    public function readTargetContent(SubmissionEntity $submission): EntityInterface
+    public function readTargetContent(SubmissionEntity $submission): Entity
     {
         $wrapper = $this->getWrapper($submission->getContentType());
         $this->ensureTargetBlogId($submission);
@@ -203,7 +203,7 @@ class ContentHelper
         return $metadata;
     }
 
-    public function writeTargetContent(SubmissionEntity $submission, EntityInterface $entity): EntityInterface
+    public function writeTargetContent(SubmissionEntity $submission, Entity $entity): Entity
     {
         $wrapper = $this->getWrapper($submission->getContentType());
 
@@ -316,7 +316,7 @@ class ContentHelper
         }
 
         try {
-            if (($this->getIoFactory()->getMapper($contentType)->get($contentId)) instanceof EntityInterface) {
+            if (($this->getIoFactory()->getMapper($contentType)->get($contentId)) instanceof Entity) {
                 $result = true;
             }
         } catch (Exception) {

--- a/inc/Smartling/Helpers/ContentHelper.php
+++ b/inc/Smartling/Helpers/ContentHelper.php
@@ -247,7 +247,7 @@ class ContentHelper
         $wrapper = $this->getWrapper($submission->getContentType());
         $this->ensureTargetBlogId($submission);
         $targetEntity = $wrapper->get($submission->getTargetId());
-        if ($targetEntity instanceof EntityAbstract) {
+        if ($targetEntity instanceof EntityWithMetadata) {
             foreach ($metadata as $key => $value) {
                 $targetEntity->setMetaTag($key, $value);
             }

--- a/inc/Smartling/Helpers/ContentHelper.php
+++ b/inc/Smartling/Helpers/ContentHelper.php
@@ -134,10 +134,10 @@ class ContentHelper
         }
     }
 
-    private function getWrapper(string $contentType): EntityHandler
+    private function getWrapper(string $contentType): EntityAbstract|EntityHandler
     {
         $return = clone $this->getIoFactory()->getHandler($contentType);
-        if (!$return instanceof EntityHandler) {
+        if (!$return instanceof EntityHandler && !$return instanceof EntityAbstract) {
             throw new \RuntimeException("Handler for $contentType expected to be " . EntityHandler::class . ", factory returned " . get_class($return));
         }
 

--- a/inc/Smartling/Helpers/ContentHelper.php
+++ b/inc/Smartling/Helpers/ContentHelper.php
@@ -5,7 +5,6 @@ namespace Smartling\Helpers;
 use Exception;
 use Smartling\DbAl\WordpressContentEntities\Entity;
 use Smartling\DbAl\WordpressContentEntities\EntityHandler;
-use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
 use Smartling\DbAl\WordpressContentEntities\EntityWithMetadata;
 use Smartling\DbAl\WordpressContentEntities\PostEntityStd;
 use Smartling\DbAl\WordpressContentEntities\TaxonomyEntityStd;
@@ -134,10 +133,10 @@ class ContentHelper
         }
     }
 
-    private function getWrapper(string $contentType): EntityAbstract|EntityHandler
+    private function getWrapper(string $contentType): EntityHandler
     {
         $return = clone $this->getIoFactory()->getHandler($contentType);
-        if (!$return instanceof EntityHandler && !$return instanceof EntityAbstract) {
+        if (!$return instanceof EntityHandler) {
             throw new \RuntimeException("Handler for $contentType expected to be " . EntityHandler::class . ", factory returned " . get_class($return));
         }
 

--- a/inc/Smartling/Helpers/EventParameters/AfterDeserializeContentEventParameters.php
+++ b/inc/Smartling/Helpers/EventParameters/AfterDeserializeContentEventParameters.php
@@ -2,7 +2,7 @@
 
 namespace Smartling\Helpers\EventParameters;
 
-use Smartling\DbAl\WordpressContentEntities\EntityInterface;
+use Smartling\DbAl\WordpressContentEntities\Entity;
 use Smartling\Submissions\SubmissionEntity;
 
 class AfterDeserializeContentEventParameters
@@ -11,14 +11,14 @@ class AfterDeserializeContentEventParameters
 
     private SubmissionEntity $submission;
 
-    private EntityInterface $targetContent;
+    private Entity $targetContent;
 
     private array $targetMetadata;
 
     public function __construct(
         array &$source,
         SubmissionEntity $submission,
-        EntityInterface $contentEntity,
+        Entity $contentEntity,
         array $meta
     )
     {
@@ -38,7 +38,7 @@ class AfterDeserializeContentEventParameters
         return $this->submission;
     }
 
-    public function getTargetContent(): EntityInterface
+    public function getTargetContent(): Entity
     {
         return $this->targetContent;
     }

--- a/inc/Smartling/Helpers/EventParameters/AfterDeserializeContentEventParameters.php
+++ b/inc/Smartling/Helpers/EventParameters/AfterDeserializeContentEventParameters.php
@@ -2,114 +2,49 @@
 
 namespace Smartling\Helpers\EventParameters;
 
-use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
+use Smartling\DbAl\WordpressContentEntities\EntityInterface;
 use Smartling\Submissions\SubmissionEntity;
 
-/**
- * Class AfterDeserializeContentEventParameters
- *
- * @package Smartling\Helpers\EventParameters
- */
 class AfterDeserializeContentEventParameters
 {
+    private array $translatedFields;
 
-    /**
-     * @var array
-     */
-    private $translatedFields;
+    private SubmissionEntity $submission;
 
-    /**
-     * @var SubmissionEntity
-     */
-    private $submission;
+    private EntityInterface $targetContent;
 
-    /**
-     * @var EntityAbstract
-     */
-    private $targetContent;
-
-    /**
-     * @var array
-     */
-    private $targetMetadata;
-
+    private array $targetMetadata;
 
     public function __construct(
-        array & $source,
+        array &$source,
         SubmissionEntity $submission,
-        EntityAbstract $contentEntity,
+        EntityInterface $contentEntity,
         array $meta
     )
     {
-        $this->setTranslatedFields($source);
-        $this->setSubmission($submission);
-        $this->setTargetContent($contentEntity);
-        $this->setTargetMetadata($meta);
+        $this->translatedFields = &$source;
+        $this->submission = $submission;
+        $this->targetContent = $contentEntity;
+        $this->targetMetadata = $meta;
     }
 
-    /**
-     * @return array
-     */
-    public function &getTranslatedFields()
+    public function &getTranslatedFields(): array
     {
         return $this->translatedFields;
     }
 
-    /**
-     * @param array $translatedFields
-     */
-    private function setTranslatedFields(& $translatedFields)
-    {
-        $this->translatedFields = &$translatedFields;
-    }
-
-    /**
-     * @return SubmissionEntity
-     */
-    public function getSubmission()
+    public function getSubmission(): SubmissionEntity
     {
         return $this->submission;
     }
 
-    /**
-     * @param SubmissionEntity $submission
-     */
-    private function setSubmission($submission)
-    {
-        $this->submission = $submission;
-    }
-
-    /**
-     * @return EntityAbstract
-     */
-    public function getTargetContent()
+    public function getTargetContent(): EntityInterface
     {
         return $this->targetContent;
     }
 
-    /**
-     * @param EntityAbstract $targetContent
-     */
-    private function setTargetContent($targetContent)
-    {
-        $this->targetContent = $targetContent;
-    }
-
-    /**
-     * @return array
-     */
-    public function getTargetMetadata()
+    public function getTargetMetadata(): array
     {
         return $this->targetMetadata;
     }
-
-    /**
-     * @param array $targetMetadata
-     */
-    private function setTargetMetadata($targetMetadata)
-    {
-        $this->targetMetadata = $targetMetadata;
-    }
-
-
 }

--- a/inc/Smartling/Helpers/EventParameters/BeforeSerializeContentEventParameters.php
+++ b/inc/Smartling/Helpers/EventParameters/BeforeSerializeContentEventParameters.php
@@ -2,114 +2,52 @@
 
 namespace Smartling\Helpers\EventParameters;
 
-use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
+use Smartling\DbAl\WordpressContentEntities\EntityInterface;
 use Smartling\Submissions\SubmissionEntity;
 
-/**
- * Class BeforeSerializeContentEventParameters
- *
- * @package Smartling\Helpers\EventParameters
- */
 class BeforeSerializeContentEventParameters
 {
+    private array $preparedFields;
 
-    /**
-     * @var array
-     */
-    private $preparedFields;
+    private SubmissionEntity $submission;
 
-    /**
-     * @var SubmissionEntity
-     */
-    private $submission;
+    private EntityInterface $originalContent;
 
-    /**
-     * @var EntityAbstract
-     */
-    private $originalContent;
-
-    /**
-     * @var array
-     */
-    private $originalMetadata;
-
+    private array $originalMetadata;
 
     public function __construct(
-        array & $source,
+        array &$source,
         SubmissionEntity $submission,
-        EntityAbstract $contentEntity,
+        EntityInterface $contentEntity,
         array $meta
     )
     {
-        $this->setPreparedFields($source);
-        $this->setSubmission($submission);
-        $this->setOriginalContent($contentEntity);
-        $this->setOriginalMetadata($meta);
+        $this->originalContent = $contentEntity;
+        $this->originalMetadata = $meta;
+        $this->preparedFields = &$source;
+        $this->submission = $submission;
     }
 
     /**
      * @return array by reference for update
      */
-    public function &getPreparedFields()
+    public function &getPreparedFields(): array
     {
         return $this->preparedFields;
     }
 
-    /**
-     * @param array $preparedFields
-     */
-    private function setPreparedFields(& $preparedFields)
-    {
-        $this->preparedFields = &$preparedFields;
-    }
-
-    /**
-     * @return SubmissionEntity
-     */
-    public function getSubmission()
+    public function getSubmission(): SubmissionEntity
     {
         return $this->submission;
     }
 
-    /**
-     * @param SubmissionEntity $submission
-     */
-    private function setSubmission($submission)
-    {
-        $this->submission = $submission;
-    }
-
-    /**
-     * @return EntityAbstract
-     */
-    public function getOriginalContent()
+    public function getOriginalContent(): EntityInterface
     {
         return $this->originalContent;
     }
 
-    /**
-     * @param EntityAbstract $originalContent
-     */
-    private function setOriginalContent($originalContent)
-    {
-        $this->originalContent = $originalContent;
-    }
-
-    /**
-     * @return array
-     */
-    public function getOriginalMetadata()
+    public function getOriginalMetadata(): array
     {
         return $this->originalMetadata;
     }
-
-    /**
-     * @param array $originalMetadata
-     */
-    private function setOriginalMetadata($originalMetadata)
-    {
-        $this->originalMetadata = $originalMetadata;
-    }
-
-
 }

--- a/inc/Smartling/Helpers/EventParameters/BeforeSerializeContentEventParameters.php
+++ b/inc/Smartling/Helpers/EventParameters/BeforeSerializeContentEventParameters.php
@@ -2,7 +2,7 @@
 
 namespace Smartling\Helpers\EventParameters;
 
-use Smartling\DbAl\WordpressContentEntities\EntityInterface;
+use Smartling\DbAl\WordpressContentEntities\Entity;
 use Smartling\Submissions\SubmissionEntity;
 
 class BeforeSerializeContentEventParameters
@@ -11,14 +11,14 @@ class BeforeSerializeContentEventParameters
 
     private SubmissionEntity $submission;
 
-    private EntityInterface $originalContent;
+    private Entity $originalContent;
 
     private array $originalMetadata;
 
     public function __construct(
         array &$source,
         SubmissionEntity $submission,
-        EntityInterface $contentEntity,
+        Entity $contentEntity,
         array $meta
     )
     {
@@ -41,7 +41,7 @@ class BeforeSerializeContentEventParameters
         return $this->submission;
     }
 
-    public function getOriginalContent(): EntityInterface
+    public function getOriginalContent(): Entity
     {
         return $this->originalContent;
     }

--- a/inc/Smartling/Helpers/FileUriHelper.php
+++ b/inc/Smartling/Helpers/FileUriHelper.php
@@ -2,13 +2,10 @@
 namespace Smartling\Helpers;
 
 use InvalidArgumentException;
-use LogicException;
 use Smartling\Bootstrap;
 
-use Smartling\DbAl\WordpressContentEntities\EntityHandler;
 use Smartling\DbAl\WordpressContentEntities\PostEntityStd;
 use Smartling\DbAl\WordpressContentEntities\TaxonomyEntityStd;
-use Smartling\DbAl\WordpressContentEntities\VirtualEntityAbstract;
 
 use Smartling\Exception\BlogNotFoundException;
 use Smartling\Exception\SmartlingConfigException;
@@ -26,12 +23,7 @@ class FileUriHelper
         }
     }
 
-    /**
-     * @param mixed $string
-     * @param SubmissionEntity $entity
-     * @return string
-     */
-    private static function preparePermalink($string, SubmissionEntity $entity): string
+    private static function preparePermalink(mixed $string, SubmissionEntity $entity): string
     {
         self::checkSubmission($entity);
         $fallBack = rtrim($entity->getSourceTitle(false), '/');
@@ -71,14 +63,10 @@ class FileUriHelper
     }
 
     /**
-     * @param SubmissionEntity $submission
-     *
-     * @return string
      * @throws BlogNotFoundException
      * @throws SmartlingInvalidFactoryArgumentException
      * @throws SmartlingDirectRunRuntimeException
      * @throws InvalidArgumentException
-     * @throws LogicException
      */
     public static function generateFileUri(SubmissionEntity $submission): string
     {
@@ -99,16 +87,8 @@ class FileUriHelper
         } elseif ($ioWrapper instanceof PostEntityStd) {
             /* post-based content */
             $permalink = self::preparePermalink(get_permalink($submission->getSourceId()), $submission);
-        } elseif ($ioWrapper instanceof VirtualEntityAbstract || $ioWrapper instanceof EntityHandler) {
-            $permalink = self::preparePermalink('', $submission);
         } else {
-            $message = vsprintf(
-                'Original entity should be based on PostEntity or TaxonomyEntityAbstract or VirtualEntityAbstract and should be an appropriate ancestor of Smartling DBAL classes. Got:%s',
-                [
-                    get_class($ioWrapper),
-                ]
-            );
-            throw new LogicException($message);
+            $permalink = self::preparePermalink('', $submission);
         }
 
         $fileUri = vsprintf(

--- a/inc/Smartling/Helpers/FileUriHelper.php
+++ b/inc/Smartling/Helpers/FileUriHelper.php
@@ -5,11 +5,13 @@ use InvalidArgumentException;
 use LogicException;
 use Smartling\Bootstrap;
 
+use Smartling\DbAl\WordpressContentEntities\EntityHandler;
 use Smartling\DbAl\WordpressContentEntities\PostEntityStd;
 use Smartling\DbAl\WordpressContentEntities\TaxonomyEntityStd;
 use Smartling\DbAl\WordpressContentEntities\VirtualEntityAbstract;
 
 use Smartling\Exception\BlogNotFoundException;
+use Smartling\Exception\SmartlingConfigException;
 use Smartling\Exception\SmartlingDirectRunRuntimeException;
 use Smartling\Exception\SmartlingInvalidFactoryArgumentException;
 use Smartling\Processors\ContentEntitiesIOFactory;
@@ -50,14 +52,22 @@ class FileUriHelper
 
     private static function getSiteHelper(): SiteHelper
     {
-        return Bootstrap::getContainer()
-                        ->get('site.helper');
+        $id = 'site.helper';
+        $result = Bootstrap::getContainer()->get($id);
+        if (!$result instanceof SiteHelper) {
+            throw new SmartlingConfigException("$id is expected to be " . SiteHelper::class);
+        }
+        return $result;
     }
 
     private static function getIoFactory(): ContentEntitiesIOFactory
     {
-        return Bootstrap::getContainer()
-                        ->get('factory.contentIO');
+        $id = 'factory.contentIO';
+        $result = Bootstrap::getContainer()->get($id);
+        if (!$result instanceof ContentEntitiesIOFactory) {
+            throw new SmartlingConfigException("$id is expected to be " . ContentEntitiesIOFactory::class);
+        }
+        return $result;
     }
 
     /**
@@ -92,6 +102,8 @@ class FileUriHelper
         } elseif ($ioWrapper instanceof VirtualEntityAbstract) {
             /* widget content */
             $permalink = self::preparePermalink('', $submission);
+        } elseif ($ioWrapper instanceof EntityHandler) {
+            $permalink = self::preparePermalink($ioWrapper->getTitle($submission->getSourceId()), $submission);
         } else {
             $message = vsprintf(
                 'Original entity should be based on PostEntity or TaxonomyEntityAbstract or VirtualEntityAbstract and should be an appropriate ancestor of Smartling DBAL classes. Got:%s',

--- a/inc/Smartling/Helpers/FileUriHelper.php
+++ b/inc/Smartling/Helpers/FileUriHelper.php
@@ -99,11 +99,8 @@ class FileUriHelper
         } elseif ($ioWrapper instanceof PostEntityStd) {
             /* post-based content */
             $permalink = self::preparePermalink(get_permalink($submission->getSourceId()), $submission);
-        } elseif ($ioWrapper instanceof VirtualEntityAbstract) {
-            /* widget content */
+        } elseif ($ioWrapper instanceof VirtualEntityAbstract || $ioWrapper instanceof EntityHandler) {
             $permalink = self::preparePermalink('', $submission);
-        } elseif ($ioWrapper instanceof EntityHandler) {
-            $permalink = self::preparePermalink($ioWrapper->getTitle($submission->getSourceId()), $submission);
         } else {
             $message = vsprintf(
                 'Original entity should be based on PostEntity or TaxonomyEntityAbstract or VirtualEntityAbstract and should be an appropriate ancestor of Smartling DBAL classes. Got:%s',

--- a/inc/Smartling/Helpers/RawDbQueryHelper.php
+++ b/inc/Smartling/Helpers/RawDbQueryHelper.php
@@ -3,27 +3,17 @@
 namespace Smartling\Helpers;
 
 /**
- * Class RawDbQueryHelper
- *
- * @package Smartling\Helpers
- *
  * This helper is designed to make raw queries to database and get raw results for debug activities only.
  */
 class RawDbQueryHelper
 {
-
-    /**
-     * @param string $tableName
-     *
-     * @return string
-     */
-    public static function getTableName($tableName)
+    public static function getTableName(string $tableName): string
     {
         if (in_array($tableName, self::getWpdb()->tables(), true)) {
             return self::getWpdb()->{$tableName};
-        } else {
-            return self::getWpdb()->base_prefix . $tableName;
         }
+
+        return self::getWpdb()->base_prefix . $tableName;
     }
 
     /**
@@ -39,15 +29,9 @@ class RawDbQueryHelper
         return $wpdb;
     }
 
-    /**
-     * @param string $query
-     *
-     * @return array
-     */
-    public static function query($query)
+    public static function query(string $query): ?array
     {
         return self::getWpdb()
                    ->get_results($query, ARRAY_A);
     }
-
 }

--- a/inc/Smartling/Helpers/Serializers/SerializationManager.php
+++ b/inc/Smartling/Helpers/Serializers/SerializationManager.php
@@ -2,38 +2,25 @@
 
 namespace Smartling\Helpers\Serializers;
 
+use Smartling\Exception\SmartlingConfigException;
 use Smartling\Processors\SmartlingFactoryAbstract;
 
-/**
- * Class SerializationManager
- * @package Smartling\Helpers\Serializers
- */
 class SerializationManager extends SmartlingFactoryAbstract
 {
-    /**
-     * ContentTypeManager constructor.
-     */
-    public function __construct()
-    {
-        parent::__construct();
-        $this->setAllowDefault(false);
-    }
-
-    /**
-     * @param SerializerInterface $serializer
-     */
+    /** @noinspection PhpUnused used in DI*/
     public function addSerializer(SerializerInterface $serializer)
     {
         $this->registerHandler($serializer->getType(), $serializer);
     }
 
-    /**
-     * @param $type
-     *
-     * @return object
-     */
-    public function getSerializer($type)
+    /** @noinspection PhpUnused */
+    public function getSerializer(string $type): SerializerInterface
     {
-        return $this->getHandler($type);
+        $result = $this->getHandler($type);
+        if ($result instanceof SerializerInterface) {
+            return $result;
+        }
+
+        throw new SmartlingConfigException(self::class . __METHOD__ . ' should return ' . SerializerInterface::class);
     }
 }

--- a/inc/Smartling/Helpers/WordpressFunctionProxyHelper.php
+++ b/inc/Smartling/Helpers/WordpressFunctionProxyHelper.php
@@ -81,7 +81,11 @@ class WordpressFunctionProxyHelper
 
     public function get_plugins(): array
     {
-        return get_plugins(...func_get_args());
+        if (function_exists('get_plugins')) {
+            return get_plugins(...func_get_args());
+        }
+
+        return [];
     }
 
     public function get_post()

--- a/inc/Smartling/Helpers/WordpressFunctionProxyHelper.php
+++ b/inc/Smartling/Helpers/WordpressFunctionProxyHelper.php
@@ -84,6 +84,11 @@ class WordpressFunctionProxyHelper
         return get_plugins(...func_get_args());
     }
 
+    public function get_post()
+    {
+        return get_post(...func_get_args());
+    }
+
     public function get_terms()
     {
         return get_terms(...func_get_args());

--- a/inc/Smartling/Processors/ContentEntitiesIOFactory.php
+++ b/inc/Smartling/Processors/ContentEntitiesIOFactory.php
@@ -3,7 +3,6 @@
 namespace Smartling\Processors;
 
 use Smartling\Bootstrap;
-use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
 use Smartling\DbAl\WordpressContentEntities\EntityHandler;
 use Smartling\Exception\SmartlingConfigException;
 use Smartling\Exception\SmartlingInvalidFactoryArgumentException;
@@ -19,16 +18,15 @@ class ContentEntitiesIOFactory extends SmartlingFactoryAbstract
     /**
      * @throws SmartlingInvalidFactoryArgumentException
      */
-    public function getMapper(string $contentType): EntityAbstract|EntityHandler
+    public function getMapper(string $contentType): EntityHandler
     {
         $obj = $this->getHandler($contentType);
 
-        if ($obj instanceof EntityAbstract || $obj instanceof EntityHandler) {
+        if ($obj instanceof EntityHandler) {
             return clone $obj;
         }
 
         Bootstrap::DebugPrint([$contentType,$obj],true);
-        throw new SmartlingConfigException(self::class . __METHOD__ . ' expected return is '
-            . EntityAbstract::class . ' or ' . EntityHandler::class);
+        throw new SmartlingConfigException(self::class . __METHOD__ . ' expected return is ' . EntityHandler::class);
     }
 }

--- a/inc/Smartling/Processors/ContentEntitiesIOFactory.php
+++ b/inc/Smartling/Processors/ContentEntitiesIOFactory.php
@@ -4,50 +4,31 @@ namespace Smartling\Processors;
 
 use Smartling\Bootstrap;
 use Smartling\DbAl\WordpressContentEntities\EntityAbstract;
+use Smartling\DbAl\WordpressContentEntities\EntityHandler;
+use Smartling\Exception\SmartlingConfigException;
 use Smartling\Exception\SmartlingInvalidFactoryArgumentException;
 
-/**
- * Class ContentEntitiesIOFactory
- *
- * @package Smartling\Processors
- */
 class ContentEntitiesIOFactory extends SmartlingFactoryAbstract
 {
-
-    /**
-     * ContentEntitiesIOFactory constructor.
-     */
-    public function __construct()
+    public function __construct(bool $allowDefault = false, ?object $defaultHandler = null)
     {
-        parent::__construct();
+        parent::__construct($allowDefault, $defaultHandler);
         $this->message = 'Requested entity wrapper for content-type \'%s\' is not registered. Called by: %s';
     }
 
     /**
-     * @param                $contentType
-     * @param EntityAbstract $mapper
-     * @param bool           $force
-     */
-    public function registerMapper($contentType, $mapper, $force = false)
-    {
-        parent::registerHandler($contentType, $mapper, $force);
-    }
-
-    /**
-     * @param $contentType
-     *
-     * @return EntityAbstract
      * @throws SmartlingInvalidFactoryArgumentException
      */
-    public function getMapper($contentType)
+    public function getMapper(string $contentType): EntityAbstract|EntityHandler
     {
-        $obj = parent::getHandler($contentType);
+        $obj = $this->getHandler($contentType);
 
-        if (is_object($obj)){
+        if ($obj instanceof EntityAbstract || $obj instanceof EntityHandler) {
             return clone $obj;
-        } else {
-            Bootstrap::DebugPrint([$contentType,$obj],true);
         }
 
+        Bootstrap::DebugPrint([$contentType,$obj],true);
+        throw new SmartlingConfigException(self::class . __METHOD__ . ' expected return is '
+            . EntityAbstract::class . ' or ' . EntityHandler::class);
     }
 }

--- a/inc/Smartling/WP/Controller/SmartlingListTable.php
+++ b/inc/Smartling/WP/Controller/SmartlingListTable.php
@@ -3,7 +3,6 @@
 namespace Smartling\WP\Controller;
 
 use Smartling\Bootstrap;
-use Smartling\ContentTypes\ContentTypeInterface;
 use Smartling\ContentTypes\ContentTypeManager;
 use Smartling\Helpers\DateTimeHelper;
 use Smartling\Helpers\SiteHelper;
@@ -40,10 +39,9 @@ class SmartlingListTable extends WP_List_Table
         foreach ($supportedTypes as $contentTypeName => $contentTypeLabel) {
             $descriptor = $contentTypeManager->getDescriptorByType($contentTypeName);
 
-            if (true === $descriptor->getVisibility()[$page]) {
-                if ($descriptor->isVirtual() || in_array($contentTypeName, $registeredInWordpressTypes, true)) {
-                    $output[$contentTypeName] = $contentTypeLabel;
-                }
+            if ($descriptor->isVisible($page) &&
+                ($descriptor->isVirtual() || in_array($contentTypeName, $registeredInWordpressTypes, true))) {
+                $output[$contentTypeName] = $contentTypeLabel;
             }
         }
 

--- a/inc/Smartling/WP/Controller/SmartlingListTable.php
+++ b/inc/Smartling/WP/Controller/SmartlingListTable.php
@@ -40,10 +40,6 @@ class SmartlingListTable extends WP_List_Table
         foreach ($supportedTypes as $contentTypeName => $contentTypeLabel) {
             $descriptor = $contentTypeManager->getDescriptorByType($contentTypeName);
 
-            if (!($descriptor instanceof ContentTypeInterface)) {
-                continue;
-            }
-
             if (true === $descriptor->getVisibility()[$page]) {
                 if ($descriptor->isVirtual() || in_array($contentTypeName, $registeredInWordpressTypes, true)) {
                     $output[$contentTypeName] = $contentTypeLabel;

--- a/inc/Smartling/WP/Table/BulkSubmitTableWidget.php
+++ b/inc/Smartling/WP/Table/BulkSubmitTableWidget.php
@@ -374,20 +374,12 @@ class BulkSubmitTableWidget extends SmartlingListTable
         $dataAsArray = [];
         if ($data) {
             foreach ($data as $item) {
-
-                $row = $item->toBulkSubmitScreenRow();
-
-                if (isset($row['id'], $row['type'])) {
-                    $entities = $this->getManager()
-                        ->find([
-                                   SubmissionEntity::FIELD_SOURCE_BLOG_ID => $this->siteHelper->getCurrentBlogId(),
-                                   SubmissionEntity::FIELD_SOURCE_ID      => $row['id'],
-                                   SubmissionEntity::FIELD_CONTENT_TYPE   => $this->getContentTypeFilterValue(),
-                               ]
-                        );
-                } else {
-                    continue;
-                }
+                $row = $item->toBulkSubmitScreenRow()->toArray();
+                $entities = $this->getManager()->find([
+                    SubmissionEntity::FIELD_SOURCE_BLOG_ID => $this->siteHelper->getCurrentBlogId(),
+                    SubmissionEntity::FIELD_SOURCE_ID => $row['id'],
+                    SubmissionEntity::FIELD_CONTENT_TYPE => $this->getContentTypeFilterValue(),
+                ]);
 
                 if (count($entities) > 0) {
                     $locales = [];
@@ -407,8 +399,6 @@ class BulkSubmitTableWidget extends SmartlingListTable
                     $row['title'] = HtmlTagGeneratorHelper::tag('span', $shrinked, ['title' => $orig]);
                 }
 
-                //$row['title']  = $this->applyRowActions( $row );
-
                 $updatedDate = '';
                 if (!StringHelper::isNullOrEmpty($row['updated'])) {
                     $dt = DateTimeHelper::stringToDateTime($row['updated']);
@@ -418,7 +408,7 @@ class BulkSubmitTableWidget extends SmartlingListTable
                 }
 
                 $row['updated'] = $updatedDate;
-                $row = array_merge(['bulkActionCb' => $this->column_cb($row)], $row);
+                $row['bulkActionCb'] = $this->column_cb($row);
                 $dataAsArray[] = $row;
             }
         }

--- a/inc/Smartling/WP/Table/BulkSubmitTableWidget.php
+++ b/inc/Smartling/WP/Table/BulkSubmitTableWidget.php
@@ -27,20 +27,17 @@ class BulkSubmitTableWidget extends SmartlingListTable
     use CommonLogMessagesTrait;
     use LoggerSafeTrait;
 
-    /**
-     * @var string
-     */
-    private $_custom_controls_namespace = 'smartling-bulk-submit-page';
+    private const CUSTOM_CONTROLS_NAMESPACE = 'smartling-bulk-submit-page';
 
     /**
      * base name of Content-type filtering select
      */
-    const CONTENT_TYPE_SELECT_ELEMENT_NAME = 'content-type';
+    private const CONTENT_TYPE_SELECT_ELEMENT_NAME = 'content-type';
 
     /**
      * base name of title search textbox
      */
-    const TITLE_SEARCH_TEXTBOX_ELEMENT_NAME = 'title-search';
+    private const TITLE_SEARCH_TEXTBOX_ELEMENT_NAME = 'title-search';
 
     /**
      * default values of custom form elements on page
@@ -380,8 +377,6 @@ class BulkSubmitTableWidget extends SmartlingListTable
 
                 $row = $item->toBulkSubmitScreenRow();
 
-                $entities = [];
-
                 if (isset($row['id'], $row['type'])) {
                     $entities = $this->getManager()
                         ->find([
@@ -440,7 +435,6 @@ class BulkSubmitTableWidget extends SmartlingListTable
 
     private function getFilteredAllowedTypes()
     {
-
         $types = $this->getActiveContentTypes($this->siteHelper, 'bulkSubmit');
 
         $restrictedTypes = WordpressContentTypeHelper::getTypesRestrictedToBulkSubmit();
@@ -568,6 +562,6 @@ class BulkSubmitTableWidget extends SmartlingListTable
      */
     private function buildHtmlTagName($name)
     {
-        return $this->_custom_controls_namespace . '-' . $name;
+        return self::CUSTOM_CONTROLS_NAMESPACE . '-' . $name;
     }
 }

--- a/inc/Smartling/WP/View/BulkSubmitScreenRow.php
+++ b/inc/Smartling/WP/View/BulkSubmitScreenRow.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Smartling\WP\View;
+
+use JetBrains\PhpStorm\ArrayShape;
+
+class BulkSubmitScreenRow {
+    private mixed $id;
+    private string $title;
+    private string $type;
+    private ?string $author;
+    private ?string $locales;
+    private ?string $status;
+    private ?string $updated;
+
+    public function __construct(mixed $id, string $title, string $type, ?string $author = null, ?string $locales = null, ?string $status = null, ?string $updated = null)
+    {
+        $this->id = $id;
+        $this->title = $title;
+        $this->type = $type;
+        $this->author = $author;
+        $this->locales = $locales;
+        $this->status = $status;
+        $this->updated = $updated;
+    }
+
+    #[ArrayShape([
+        'author' => 'string',
+        'id' => 'mixed',
+        'status' => 'string',
+        'title' => 'string',
+        'locales' => 'string',
+        'type' => 'string',
+        'updated' => 'string',
+    ])]
+    public function toArray(): array
+    {
+        return [
+            'author' => $this->author,
+            'id' => $this->id,
+            'status' => $this->status,
+            'title' => $this->title,
+            'locales' => $this->locales,
+            'type' => $this->type,
+            'updated' => $this->updated,
+        ];
+    }
+}

--- a/inc/config/services.yml
+++ b/inc/config/services.yml
@@ -108,6 +108,29 @@ services:
       - "@manager.submission"
       - "@wp.proxy"
 
+  content.gravity.forms:
+    class: Smartling\ContentTypes\ExternalContentGravityForms
+    arguments:
+      - "@factory.contentIO"
+      - "@content-type-descriptor-manager"
+      - "@content.type.helper"
+      - "@fields-filter.helper"
+      - "@content.gravity.forms.form"
+      - "@content.gravity.forms.form.handler"
+      - "@helper.gutenberg"
+      - "@helper.plugins"
+      - "@site.helper"
+      - "@manager.submission"
+      - "@wp.proxy"
+
+  content.gravity.forms.form:
+    class: Smartling\ContentTypes\GravityFormsForm
+
+  content.gravity.forms.form.handler:
+    class: Smartling\DbAl\WordpressContentEntities\GravityFormsFormHandler
+    arguments:
+      - "@site.db"
+
   content.relations.handler:
     class: Smartling\Services\ContentRelationsHandler
     arguments:
@@ -145,6 +168,7 @@ services:
       - ["addHandler", ["@content.aioseo"]]
       - ["addHandler", ["@content.beaver.builder"]]
       - ["addHandler", ["@content.elementor"]]
+      - ["addHandler", ["@content.gravity.forms"]]
 
   manager.job:
     class: Smartling\Jobs\JobManager
@@ -348,9 +372,11 @@ services:
 
   meta-field.processor.manager:
     class: Smartling\Helpers\MetaFieldProcessor\MetaFieldProcessorManager
+    arguments:
+      - "@acf.type.detector"
+      - true
+      - "@default.meta-field-processor"
     calls:
-      - [ "setDefaultHandler", [ "@default.meta-field-processor" ] ]
-      - [ "setAcfTypeDetector", [ "@acf.type.detector" ] ]
       - [ "registerProcessor", ["@post.content.processor"]]
 
   service.side-removal-handler:
@@ -382,9 +408,9 @@ services:
 
   content.helper:
     class: Smartling\Helpers\ContentHelper
-    calls:
-      - [ "setIoFactory", [ "@factory.contentIO" ]]
-      - [ "setSiteHelper", [ "@site.helper" ]]
+    arguments:
+      - "@factory.contentIO"
+      - "@site.helper"
 
   fields-filter.helper:
     class: Smartling\Helpers\FieldsFilterHelper

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 8.0
-Stable tag: 3.0.3
+Stable tag: 3.1.0
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 3.1.0 =
+* Added Gravity Forms support
+
 = 3.0.3 =
 * Fixed wrong content IDs being sent for translation when sending related content one or two levels deep
 * Fixed plugin unable to change target content IDs when encountering a non-standard post type

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -10,7 +10,7 @@ use Smartling\Bootstrap;
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           3.0.3
+ * Version:           3.1.0
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/Services/ContentRelationDiscoveryServiceTest.php
+++ b/tests/Services/ContentRelationDiscoveryServiceTest.php
@@ -671,7 +671,6 @@ namespace Smartling\Tests\Services {
                 'post_content' => "<!-- wp:test {\"relatedContent\":$relatedPostId} /-->",
                 'post_parent' => $postParentId,
             ]);
-            $mapper->method('getMetadata')->willReturn([]);
 
             $metaFieldProcessorManager = $this->createMock(MetaFieldProcessorManager::class);
             $metaFieldProcessorManager->method('getProcessor')->willReturnCallback(function ($field) {

--- a/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
+++ b/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Smartling\Base\SmartlingCoreUploadTrait;
 use Smartling\ContentTypes\ExternalContentManager;
-use Smartling\DbAl\WordpressContentEntities\PostEntityStdWithPostStatus;
+use Smartling\DbAl\WordpressContentEntities\PostEntityStd;
 use Smartling\Extensions\Acf\AcfDynamicSupport;
 use Smartling\Helpers\ContentHelper;
 use Smartling\Helpers\DecodedXml;
@@ -14,7 +14,6 @@ use Smartling\Helpers\FieldsFilterHelper;
 use Smartling\Helpers\GutenbergBlockHelper;
 use Smartling\Helpers\PostContentHelper;
 use Smartling\Helpers\Serializers\SerializerJsonWithFallback;
-use Smartling\Helpers\TestRunHelper;
 use Smartling\Helpers\WordpressFunctionProxyHelper;
 use Smartling\Helpers\XmlHelper;
 use Smartling\Replacers\ReplacerFactory;
@@ -31,22 +30,18 @@ class SmartlingCoreUpload {
     use SmartlingCoreUploadTrait;
 
     private ContentHelper $contentHelper;
-    private ExternalContentManager $externalContentManager;
     private FieldsFilterHelper $fieldsFilterHelper;
     private GutenbergBlockHelper $blockHelper;
     private SettingsManager $settingsManager;
     private SubmissionManager $submissionManager;
-    private TestRunHelper $testRunHelper;
     private WordpressFunctionProxyHelper $wpProxy;
 
-    public function __construct(ContentHelper $contentHelper, ExternalContentManager $externalContentManager, FieldsFilterHelper $fieldsFilterHelper, SettingsManager $settingsManager, SubmissionManager $submissionManager, TestRunHelper $testRunHelper, WordpressFunctionProxyHelper $wpProxy)
+    public function __construct(ContentHelper $contentHelper, FieldsFilterHelper $fieldsFilterHelper, SettingsManager $settingsManager, SubmissionManager $submissionManager, WordpressFunctionProxyHelper $wpProxy)
     {
         $this->contentHelper = $contentHelper;
-        $this->externalContentManager = $externalContentManager;
         $this->fieldsFilterHelper = $fieldsFilterHelper;
         $this->settingsManager = $settingsManager;
         $this->submissionManager = $submissionManager;
-        $this->testRunHelper = $testRunHelper;
         $this->wpProxy = $wpProxy;
     }
 
@@ -91,7 +86,7 @@ class SmartlingCoreUpload {
 
 class SmartlingCoreUploadTraitTest extends TestCase
 {
-    private PostEntityStdWithPostStatus $resultEntity;
+    private PostEntityStd $resultEntity;
 
     public function setUp(): void
     {
@@ -139,7 +134,7 @@ class SmartlingCoreUploadTraitTest extends TestCase
         $contentHelper = $this->getMockBuilder(ContentHelper::class)->disableOriginalConstructor()->getMock();
         $contentHelper->method('readSourceContent')->willReturnArgument(0);
         $contentHelper->method('readSourceMetadata')->willReturn([]);
-        $contentHelper->method('readTargetContent')->willReturn(new PostEntityStdWithPostStatus());
+        $contentHelper->method('readTargetContent')->willReturn(new PostEntityStd());
         $contentHelper->method('readTargetMetadata')->willReturn(['locked' => 'a:1:{s:5:"title";s:19:"Se våra prisplaner";}', 'unlocked' => 'unlocked']);
 
         $fieldsFilterHelper = $this->createPartialMock(FieldsFilterHelper::class, ['applyTranslatedValues', 'getLogger', 'processStringsAfterDecoding']);
@@ -289,7 +284,7 @@ HTML;
 <!-- /wp:folder -->
 HTML;
 
-        $target = new PostEntityStdWithPostStatus();
+        $target = new PostEntityStd();
         $target->setPostContent($targetContent);
 
         $submission = $this->createMock(SubmissionEntity::class);
@@ -358,6 +353,6 @@ HTML;
             return is_serialized($original) ? @unserialize($original) : $original;
         });
 
-        return new SmartlingCoreUpload($contentHelper, $externalContentManager, $fieldsFilterHelper, $settingsManager, $submissionManager, $this->createMock(TestRunHelper::class), $wpProxy);
+        return new SmartlingCoreUpload($contentHelper, $fieldsFilterHelper, $settingsManager, $submissionManager, $wpProxy);
     }
 }

--- a/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
+++ b/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
@@ -136,7 +136,7 @@ class SmartlingCoreUploadTraitTest extends TestCase
         $submission = $this->createMock(SubmissionEntity::class);
         $submission->method('getLockedFields')->willReturn(['meta/locked']);
         $submission->method('getTargetId')->willReturn(1 );
-        $contentHelper = $this->getMockBuilder(ContentHelper::class)->disableOriginalConstructor()->getMock();
+        $contentHelper = $this->createMock(ContentHelper::class);
         $contentHelper->method('readTargetContent')->willReturn(new PostEntityStd());
         $contentHelper->method('readTargetMetadata')->willReturn(['locked' => 'a:1:{s:5:"title";s:19:"Se våra prisplaner";}', 'unlocked' => 'unlocked']);
 
@@ -293,7 +293,7 @@ HTML;
         $submission = $this->createMock(SubmissionEntity::class);
         $submission->method('getLockedFields')->willReturn([]);
         $submission->method('getTargetId')->willReturn(1);
-        $contentHelper = $this->getMockBuilder(ContentHelper::class)->disableOriginalConstructor()->getMock();
+        $contentHelper = $this->createMock(ContentHelper::class);
         $contentHelper->method('readTargetContent')->willReturn($target);
         $contentHelper->method('readTargetMetadata')->willReturn([]);
 
@@ -310,7 +310,7 @@ HTML;
         $submissionManager = $this->getMockBuilder(SubmissionManager::class)->disableOriginalConstructor()->getMock();
         $submissionManager->method('storeEntity')->willReturnArgument(0);
 
-        $x = $this->getSmartlingCoreUpload($contentHelper,$fieldsFilterHelper, $settingsManager, $submissionManager);
+        $x = $this->getSmartlingCoreUpload($contentHelper, $fieldsFilterHelper, $settingsManager, $submissionManager);
         $xmlHelper = $this->createMock(XmlHelper::class);
         $xmlHelper->method('xmlDecode')->willReturn(new DecodedXml(
             ['entity' => ['post_content' => $translatedContent]],
@@ -319,6 +319,7 @@ HTML;
 
         $contentHelper->expects(self::once())->method('writeTargetContent')->willReturnCallback(function (SubmissionEntity $submission, PostEntityStd $entity) {
             $this->resultEntity = $entity;
+            return $entity;
         });
 
         $this->assertSuccessApplyXml($x, $submission, $xmlHelper);

--- a/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
+++ b/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
@@ -106,7 +106,6 @@ class SmartlingCoreUploadTraitTest extends TestCase
         $translatedFields = ['metaNotToTranslate' => 's:8:"Translated"', 'metaToTranslate' => '~Translated~'];
 
         $contentHelper = $this->createMock(ContentHelper::class);
-        $contentHelper->method('readSourceMetadata')->willReturn([]);
         $contentHelper->method('readTargetContent')->willReturn(new PostEntityStd());
 
         $fieldsFilterHelper = $this->getMockBuilder(FieldsFilterHelper::class)->disableOriginalConstructor()->getMock();
@@ -138,8 +137,6 @@ class SmartlingCoreUploadTraitTest extends TestCase
         $submission->method('getLockedFields')->willReturn(['meta/locked']);
         $submission->method('getTargetId')->willReturn(1 );
         $contentHelper = $this->getMockBuilder(ContentHelper::class)->disableOriginalConstructor()->getMock();
-        $contentHelper->method('readSourceContent')->willReturnArgument(0);
-        $contentHelper->method('readSourceMetadata')->willReturn([]);
         $contentHelper->method('readTargetContent')->willReturn(new PostEntityStd());
         $contentHelper->method('readTargetMetadata')->willReturn(['locked' => 'a:1:{s:5:"title";s:19:"Se våra prisplaner";}', 'unlocked' => 'unlocked']);
 
@@ -297,8 +294,6 @@ HTML;
         $submission->method('getLockedFields')->willReturn([]);
         $submission->method('getTargetId')->willReturn(1);
         $contentHelper = $this->getMockBuilder(ContentHelper::class)->disableOriginalConstructor()->getMock();
-        $contentHelper->method('readSourceContent')->willReturnArgument(0);
-        $contentHelper->method('readSourceMetadata')->willReturn([]);
         $contentHelper->method('readTargetContent')->willReturn($target);
         $contentHelper->method('readTargetMetadata')->willReturn([]);
 

--- a/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
+++ b/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Smartling\Base\SmartlingCoreUploadTrait;
 use Smartling\ContentTypes\ExternalContentManager;
-use Smartling\DbAl\WordpressContentEntities\PostEntityStd;
+use Smartling\DbAl\WordpressContentEntities\PostEntityStdWithPostStatus;
 use Smartling\Extensions\Acf\AcfDynamicSupport;
 use Smartling\Helpers\ContentHelper;
 use Smartling\Helpers\DecodedXml;
@@ -91,7 +91,7 @@ class SmartlingCoreUpload {
 
 class SmartlingCoreUploadTraitTest extends TestCase
 {
-    private PostEntityStd $resultEntity;
+    private PostEntityStdWithPostStatus $resultEntity;
 
     public function setUp(): void
     {
@@ -139,7 +139,7 @@ class SmartlingCoreUploadTraitTest extends TestCase
         $contentHelper = $this->getMockBuilder(ContentHelper::class)->disableOriginalConstructor()->getMock();
         $contentHelper->method('readSourceContent')->willReturnArgument(0);
         $contentHelper->method('readSourceMetadata')->willReturn([]);
-        $contentHelper->method('readTargetContent')->willReturn(new PostEntityStd());
+        $contentHelper->method('readTargetContent')->willReturn(new PostEntityStdWithPostStatus());
         $contentHelper->method('readTargetMetadata')->willReturn(['locked' => 'a:1:{s:5:"title";s:19:"Se våra prisplaner";}', 'unlocked' => 'unlocked']);
 
         $fieldsFilterHelper = $this->createPartialMock(FieldsFilterHelper::class, ['applyTranslatedValues', 'getLogger', 'processStringsAfterDecoding']);
@@ -289,7 +289,7 @@ HTML;
 <!-- /wp:folder -->
 HTML;
 
-        $target = new PostEntityStd();
+        $target = new PostEntityStdWithPostStatus();
         $target->setPostContent($targetContent);
 
         $submission = $this->createMock(SubmissionEntity::class);

--- a/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
+++ b/tests/Smartling/Base/SmartlingCoreUploadTraitTest.php
@@ -14,6 +14,7 @@ use Smartling\Helpers\FieldsFilterHelper;
 use Smartling\Helpers\GutenbergBlockHelper;
 use Smartling\Helpers\PostContentHelper;
 use Smartling\Helpers\Serializers\SerializerJsonWithFallback;
+use Smartling\Helpers\TestRunHelper;
 use Smartling\Helpers\WordpressFunctionProxyHelper;
 use Smartling\Helpers\XmlHelper;
 use Smartling\Replacers\ReplacerFactory;
@@ -30,18 +31,24 @@ class SmartlingCoreUpload {
     use SmartlingCoreUploadTrait;
 
     private ContentHelper $contentHelper;
+    private ExternalContentManager $externalContentManager;
     private FieldsFilterHelper $fieldsFilterHelper;
     private GutenbergBlockHelper $blockHelper;
     private SettingsManager $settingsManager;
     private SubmissionManager $submissionManager;
+    private TestRunHelper $testRunHelper;
     private WordpressFunctionProxyHelper $wpProxy;
 
-    public function __construct(ContentHelper $contentHelper, FieldsFilterHelper $fieldsFilterHelper, SettingsManager $settingsManager, SubmissionManager $submissionManager, WordpressFunctionProxyHelper $wpProxy)
+    public function __construct(ContentHelper $contentHelper, ExternalContentManager $externalContentManager, FieldsFilterHelper $fieldsFilterHelper, SettingsManager $settingsManager, SubmissionManager $submissionManager, TestRunHelper $testRunHelper, WordpressFunctionProxyHelper $wpProxy)
     {
         $this->contentHelper = $contentHelper;
+        /** @noinspection UnusedConstructorDependenciesInspection the way this test works, this is needed */
+        $this->externalContentManager = $externalContentManager;
         $this->fieldsFilterHelper = $fieldsFilterHelper;
         $this->settingsManager = $settingsManager;
         $this->submissionManager = $submissionManager;
+        /** @noinspection UnusedConstructorDependenciesInspection the way this test works, this is needed */
+        $this->testRunHelper = $testRunHelper;
         $this->wpProxy = $wpProxy;
     }
 
@@ -98,8 +105,7 @@ class SmartlingCoreUploadTraitTest extends TestCase
         $submission = $this->createMock(SubmissionEntity::class);
         $translatedFields = ['metaNotToTranslate' => 's:8:"Translated"', 'metaToTranslate' => '~Translated~'];
 
-        $contentHelper = $this->getMockBuilder(ContentHelper::class)->disableOriginalConstructor()->getMock();
-        $contentHelper->method('readSourceContent')->willReturnArgument(0);
+        $contentHelper = $this->createMock(ContentHelper::class);
         $contentHelper->method('readSourceMetadata')->willReturn([]);
         $contentHelper->method('readTargetContent')->willReturn(new PostEntityStd());
 
@@ -353,6 +359,6 @@ HTML;
             return is_serialized($original) ? @unserialize($original) : $original;
         });
 
-        return new SmartlingCoreUpload($contentHelper, $fieldsFilterHelper, $settingsManager, $submissionManager, $wpProxy);
+        return new SmartlingCoreUpload($contentHelper, $externalContentManager, $fieldsFilterHelper, $settingsManager, $submissionManager, $this->createMock(TestRunHelper::class), $wpProxy);
     }
 }

--- a/tests/Smartling/DbAl/WordpressContentEntities/EntityAbstractTest.php
+++ b/tests/Smartling/DbAl/WordpressContentEntities/EntityAbstractTest.php
@@ -8,7 +8,7 @@ use Smartling\Helpers\WidgetHelper;
 
 class TestWidgetEntity extends WidgetEntity
 {
-    private $testMap;
+    private array $testMap;
 
     public function __construct($type, array $map)
     {
@@ -16,7 +16,7 @@ class TestWidgetEntity extends WidgetEntity
         parent::__construct($type);
     }
 
-    public function buildMap()
+    public function buildMap(): void
     {
         $this->map = $this->testMap;
     }

--- a/tests/Smartling/DbAl/WordpressContentEntities/PostEntityStdTest.php
+++ b/tests/Smartling/DbAl/WordpressContentEntities/PostEntityStdTest.php
@@ -10,7 +10,7 @@ use Smartling\Tests\Traits\InvokeMethodTrait;
  * Class ArrayHelperTest
  *
  * @package Smartling\Tests\Smartling\Helpers
- * @covers  \Smartling\DbAl\WordpressContentEntities\PostEntityStd
+ * @covers  \Smartling\DbAl\WordpressContentEntities\PostEntityStdWithPostStatus
  */
 class PostEntityStdTest extends TestCase
 {

--- a/tests/Smartling/DbAl/WordpressContentEntities/PostEntityStdTest.php
+++ b/tests/Smartling/DbAl/WordpressContentEntities/PostEntityStdTest.php
@@ -6,35 +6,25 @@ use PHPUnit\Framework\TestCase;
 use Smartling\DbAl\WordpressContentEntities\PostEntityStd;
 use Smartling\Tests\Traits\InvokeMethodTrait;
 
-/**
- * Class ArrayHelperTest
- *
- * @package Smartling\Tests\Smartling\Helpers
- * @covers  \Smartling\DbAl\WordpressContentEntities\PostEntityStdWithPostStatus
- */
 class PostEntityStdTest extends TestCase
 {
 
     use InvokeMethodTrait;
 
     /**
-     * @covers       \Smartling\DbAl\WordpressContentEntities\PostEntityStd::areMetadataValuesUnique
      * @dataProvider areMetadataValuesUniqueDataProvider
      */
-    public function testTestIsMetaMultiValue($inpudData, $expectedResult)
+    public function testTestIsMetaMultiValue($inputData, $expectedResult)
     {
         $obj = new PostEntityStd();
 
         self::assertEquals(
             $expectedResult,
-            $this->invokeMethod($obj, 'areMetadataValuesUnique', [$inpudData])
+            $this->invokeMethod($obj, 'areMetadataValuesUnique', [$inputData])
         );
     }
 
-    /**
-     * @return array
-     */
-    public function areMetadataValuesUniqueDataProvider()
+    public function areMetadataValuesUniqueDataProvider(): array
     {
         return [
             'empty data' => [[], false],
@@ -45,12 +35,9 @@ class PostEntityStdTest extends TestCase
     }
 
     /**
-     * @covers       \Smartling\DbAl\WordpressContentEntities\PostEntityStd::formatMetadata
      * @dataProvider formatMetadataDataProvider
-     * @param array $inputData
-     * @param array $expectedResult
      */
-    public function testFormatMetadataNoException($inputData, $expectedResult)
+    public function testFormatMetadataNoException(array $inputData, array $expectedResult): void
     {
         $obj = new PostEntityStd();
 
@@ -60,7 +47,7 @@ class PostEntityStdTest extends TestCase
         );
     }
 
-    public function formatMetadataDataProvider()
+    public function formatMetadataDataProvider(): array
     {
         return [
             'one value' => [
@@ -115,9 +102,6 @@ class PostEntityStdTest extends TestCase
         ];
     }
 
-    /**
-     * @covers  \Smartling\DbAl\WordpressContentEntities\PostEntityStd::formatMetadata
-     */
     public function testFormatMetadataWithUniqueMetavalues()
     {
         $obj = new PostEntityStd();

--- a/tests/Smartling/Extensions/Acf/AcfOptionEntityTest.php
+++ b/tests/Smartling/Extensions/Acf/AcfOptionEntityTest.php
@@ -24,7 +24,7 @@ class AcfOptionEntityTest extends TestCase
             return 'wp_' . $tableName;
         });
         $db->expects($this->once())->method('fetch')->with("SELECT `option_name` FROM `wp_options` WHERE ( `option_name` LIKE 'options_%' )")->willReturn([]);
-        $x = $this->createPartialMock(AcfOptionEntity::class, ['getDbal']);
+        $x = $this->createMock(AcfOptionEntity::class);
         $x->method('getDbal')->willReturn($db);
         try {
             $x->get('guid');

--- a/tests/Smartling/Extensions/Acf/AcfOptionEntityTest.php
+++ b/tests/Smartling/Extensions/Acf/AcfOptionEntityTest.php
@@ -24,11 +24,10 @@ class AcfOptionEntityTest extends TestCase
             return 'wp_' . $tableName;
         });
         $db->expects($this->once())->method('fetch')->with("SELECT `option_name` FROM `wp_options` WHERE ( `option_name` LIKE 'options_%' )")->willReturn([]);
-        $x = $this->createMock(AcfOptionEntity::class);
-        $x->method('getDbal')->willReturn($db);
+        $x = new AcfOptionEntity($db);
         try {
             $x->get('guid');
-        } catch (EntityNotFoundException|SmartlingDirectRunRuntimeException $e) {
+        } catch (EntityNotFoundException|SmartlingDirectRunRuntimeException) {
             // Exceptions differ if running as integration test
         }
     }

--- a/tests/Smartling/Extensions/Acf/AcfTypeDetectorTest.php
+++ b/tests/Smartling/Extensions/Acf/AcfTypeDetectorTest.php
@@ -9,6 +9,7 @@ use Smartling\Helpers\Cache;
 use Smartling\Helpers\ContentHelper;
 use Smartling\Helpers\MetaFieldProcessor\BulkProcessors\MediaBasedProcessor;
 use Smartling\Helpers\SiteHelper;
+use Smartling\Processors\ContentEntitiesIOFactory;
 use Smartling\Settings\SettingsManager;
 use Smartling\Tests\Mocks\WordpressFunctionsMockHelper;
 
@@ -63,7 +64,7 @@ class AcfTypeDetectorTest extends TestCase
             '"entity\/post_content\/acf\/testimonial\/data\/_media":"field_5eb1344b55a84"}', true);
         self::assertInstanceOf(
             MediaBasedProcessor::class,
-            (new AcfTypeDetector(new ContentHelper(), new Cache()))
+            (new AcfTypeDetector(new ContentHelper($this->createMock(ContentEntitiesIOFactory::class), $siteHelper), new Cache()))
                 ->getProcessorForGutenberg(array_keys($fields)[0], $fields)
         );
     }

--- a/tests/Smartling/Helpers/ContentHelperTest.php
+++ b/tests/Smartling/Helpers/ContentHelperTest.php
@@ -24,8 +24,6 @@ class ContentHelperTest extends TestCase
      */
     public function testCheckEntityExists(int $currentBlogId, int $otherBlogId, bool $exists)
     {
-        $x = $this->getMockBuilder(ContentHelper::class)->onlyMethods(['getIoFactory', 'getSiteHelper'])->setConstructorArgs([new WordpressFunctionProxyHelper()])->getMock();
-
         $entity = $this->getMockBuilder(EntityAbstract::class)->onlyMethods(['get'])->getMockForAbstractClass();
         $entity->method('get')->willReturnSelf();
 
@@ -41,8 +39,7 @@ class ContentHelperTest extends TestCase
         $siteHelper->expects($currentBlogId === $otherBlogId ? self::never() : self::once())->method('switchBlogId')->with($otherBlogId);
         $siteHelper->expects($currentBlogId === $otherBlogId ? self::never() : self::once())->method('restoreBlogId');
 
-        $x->method('getIoFactory')->willReturn($ioFactory);
-        $x->method('getSiteHelper')->willReturn($siteHelper);
+        $x = new ContentHelper($ioFactory, $siteHelper);
 
         self::assertEquals($exists, $x->checkEntityExists($otherBlogId, 'post', 3));
     }


### PR DESCRIPTION
This is a first external plugin that needed to add a custom post type for processing. Extending EntityAbstract was the way to go, but it's design is bad. I've tried to improve upon it by creating interfaces for Entity and EntityHandler, and also created EntityWithMetadata and EntityWithPostStatus, to reduce the required effort to add new entities.