### PR TITLE
bump Elementor support version (WP-789)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "",
   "type": "wordpress-plugin",
   "repositories": [

--- a/inc/Smartling/ContentTypes/ExternalContentElementor.php
+++ b/inc/Smartling/ContentTypes/ExternalContentElementor.php
@@ -208,7 +208,7 @@ class ExternalContentElementor extends ExternalContentAbstract implements Conten
 
     public function getMaxVersion(): string
     {
-        return '3.8';
+        return '3.10';
     }
 
     public function getMinVersion(): string

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 8.0
-Stable tag: 3.1.0
+Stable tag: 3.1.1
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 3.1.1 =
+*
+
 = 3.1.0 =
 * Added Gravity Forms support
 

--- a/readme.txt
+++ b/readme.txt
@@ -63,7 +63,7 @@ Additional information on the Smartling Connector for WordPress can be found [he
 
 == Changelog ==
 = 3.1.1 =
-*
+* Added support of Elementor version 3.9 to 3.10
 
 = 3.1.0 =
 * Added Gravity Forms support

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -10,7 +10,7 @@ use Smartling\Bootstrap;
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           3.1.0
+ * Version:           3.1.1
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+
@@ -18,7 +18,7 @@ use Smartling\Bootstrap;
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       smartling-connector
  * Domain Path:       /languages
- * Elementor tested up to: 3.8.1
+ * Elementor tested up to: 3.10.2
  */
 
 // If this file is called directly, abort.


### PR DESCRIPTION
It looks like they've set the plugin to auto-update and ignored the error message, not sure what can be done to improve awareness.
The error message is displayed on every admin page:
![image](https://user-images.githubusercontent.com/60617669/216053238-54031890-243e-4c90-9031-b2a8299475ea.png)
and when updating manually, there is also
![image](https://user-images.githubusercontent.com/60617669/216053383-cf216212-788f-4a3a-b09e-7d99042c550f.png)
