### PR TITLE
fix submissions locking (WP-791)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "",
   "type": "wordpress-plugin",
   "repositories": [

--- a/readme.txt
+++ b/readme.txt
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 3.1.2 =
+* Fixed translation lock screen locking unintended submissions
+
 = 3.1.1 =
 * Added support of Elementor version 3.9 to 3.10
 

--- a/readme.txt
+++ b/readme.txt
@@ -88,9 +88,6 @@ Additional information on the Smartling Connector for WordPress can be found [he
 * Minimum required PHP version is now 8.0!
 * Fixed upload queue getting stuck
 
-= 2.16.8 =
-* Fixed translation lock screen locking unintended submissions (backport of 3.1.2)
-
 = 2.16.7 =
 * Added Beaver Builder 2.6 to supported versions
 

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 * Minimum required PHP version is now 8.0!
 * Fixed upload queue getting stuck
 
+= 2.16.8 =
+* Fixed translation lock screen locking unintended submissions (backport of 3.1.2)
+
 = 2.16.7 =
 * Added Beaver Builder 2.6 to supported versions
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 8.0
-Stable tag: 3.1.1
+Stable tag: 3.1.2
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -10,7 +10,7 @@ use Smartling\Bootstrap;
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           3.1.1
+ * Version:           3.1.2
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/Smartling/WP/Table/SubmissionTableWidgetTest.php
+++ b/tests/Smartling/WP/Table/SubmissionTableWidgetTest.php
@@ -4,7 +4,7 @@ namespace {
     if (!class_exists('WP_List_Table')) {
         class WP_List_Table
         {
-            public function __construct($a)
+            public function __construct($a = [])
             {
             }
 


### PR DESCRIPTION
A missing content type check when working with locking UI could result in locking an unintended submission