### PR TITLE
change taxonomy pages widget styles (WP-797)

### DIFF
--- a/inc/Smartling/WP/View/ContentEditJob.php
+++ b/inc/Smartling/WP/View/ContentEditJob.php
@@ -21,11 +21,7 @@ $widgetName = 'bulk-submit-locales';
 
 ?>
 <?php
-$screen = get_current_screen();
-$isBulkSubmitPage = false;
-if ($screen !== null) {
-    $isBulkSubmitPage = $screen->id === 'smartling_page_smartling-bulk-submit';
-}
+$isBulkSubmitPage = get_current_screen()?->id === 'smartling_page_smartling-bulk-submit';
 global $tag;
 $needWrapper = ($tag instanceof WP_Term);
 ?>
@@ -37,7 +33,7 @@ $needWrapper = ($tag instanceof WP_Term);
 </script>
 
 <?php if ($needWrapper) : ?>
-<div class="postbox-container">
+<div class="postbox-container" style="width: 550px">
     <div id="panel-box" class="postbox hndle"><h2><span>Translate content</span></h2>
         <div class="inside">
             <?php endif; ?>

--- a/inc/Smartling/WP/View/taxonomy-based-content-type.php
+++ b/inc/Smartling/WP/View/taxonomy-based-content-type.php
@@ -64,7 +64,7 @@ if (!empty($locales)) {
 
     <h3><?= __($widgetTitle) ?></h3>
     <?= WPAbstract::checkUncheckBlock($widgetName) ?>
-    <div style="max-width: 400px;">
+    <div style="max-width: 250px;">
         <?php
         ArrayHelper::sortLocales($locales);
         ?>

--- a/inc/Smartling/WP/View/taxonomy-based-content-type.php
+++ b/inc/Smartling/WP/View/taxonomy-based-content-type.php
@@ -59,12 +59,12 @@ if (!empty($locales)) {
     $widgetTitle = 'Download translation';
     ?>
 
-    <div id="smartling-post-widget">
+    <div id="smartling-post-widget" style="float: right;">
     <h2>Smartling connector actions</h2>
 
     <h3><?= __($widgetTitle) ?></h3>
     <?= WPAbstract::checkUncheckBlock($widgetName) ?>
-    <div style="width: 400px;">
+    <div style="max-width: 400px;">
         <?php
         ArrayHelper::sortLocales($locales);
         ?>
@@ -144,3 +144,4 @@ if (!empty($locales)) {
         <a href="<?= get_site_url() ?>/wp-admin/network/admin.php?page=smartling_configuration_profile_setup&action=edit&profile=<?= $data['profile']->getId() ?>">settings.</a>
     </div>
 <?php } ?>
+<div style="clear: both"></div>


### PR DESCRIPTION
from some point, WordPress changed form width for taxonomy pages to equal 800px, this is less than was expected, and caused weird display on these pages