### PR TITLE
remove fields on unsupported plugin version (WP-814)

### DIFF
--- a/inc/Smartling/ContentTypes/ContentTypePluggableInterface.php
+++ b/inc/Smartling/ContentTypes/ContentTypePluggableInterface.php
@@ -2,11 +2,17 @@
 
 namespace Smartling\ContentTypes;
 
+use JetBrains\PhpStorm\ExpectedValues;
 use Smartling\Submissions\SubmissionEntity;
 
 interface ContentTypePluggableInterface
 {
-    public function canHandle(string $contentType, ?int $contentId = null): bool;
+    public const NOT_SUPPORTED = 'not_supported';
+    public const SUPPORTED = 'supported';
+    public const VERSION_NOT_SUPPORTED = 'version_not_supported';
+
+    #[ExpectedValues(valuesFromClass: self::class)]
+    public function getSupportLevel(string $contentType, ?int $contentId = null): string;
 
     public function getContentFields(SubmissionEntity $submission, bool $raw): array;
 

--- a/inc/Smartling/ContentTypes/ExternalContentAbstract.php
+++ b/inc/Smartling/ContentTypes/ExternalContentAbstract.php
@@ -22,17 +22,20 @@ abstract class ExternalContentAbstract implements ContentTypePluggableInterface 
         $this->wpProxy = $wpProxy;
     }
 
-    public function canHandle(string $contentType, ?int $contentId = null): bool
+    public function getSupportLevel(string $contentType, ?int $contentId = null): string
     {
+        $result = self::NOT_SUPPORTED;
         $plugins = $this->wpProxy->get_plugins();
         foreach ($this->getPluginPaths() as $path) {
-            if (array_key_exists($path, $plugins) && $this->wpProxy->is_plugin_active($path) &&
-                $this->pluginHelper->versionInRange($plugins[$path]['Version'] ?? 0, $this->getMinVersion(), $this->getMaxVersion())) {
-                return true;
+            if (array_key_exists($path, $plugins) && $this->wpProxy->is_plugin_active($path)) {
+                if ($this->pluginHelper->versionInRange($plugins[$path]['Version'] ?? 0, $this->getMinVersion(), $this->getMaxVersion())) {
+                    return self::SUPPORTED;
+                }
+                $result = self::VERSION_NOT_SUPPORTED;
             }
         }
 
-        return false;
+        return $result;
     }
 
     public function getExternalContentTypes(): array

--- a/inc/Smartling/ContentTypes/ExternalContentAioseo.php
+++ b/inc/Smartling/ContentTypes/ExternalContentAioseo.php
@@ -93,10 +93,12 @@ class ExternalContentAioseo extends ExternalContentAbstract
         $this->siteHelper = $siteHelper;
     }
 
-    public function canHandle(string $contentType, ?int $contentId = null): bool
+    public function getSupportLevel(string $contentType, ?int $contentId = null): string
     {
-        return parent::canHandle($contentType, $contentId) &&
-            $this->contentTypeHelper->isPost($contentType);
+        if ($this->contentTypeHelper->isPost($contentType)) {
+            return parent::getSupportLevel($contentType, $contentId);
+        }
+        return self::NOT_SUPPORTED;
     }
 
     public function getContentFields(SubmissionEntity $submission, bool $raw): array

--- a/inc/Smartling/ContentTypes/ExternalContentBeaverBuilder.php
+++ b/inc/Smartling/ContentTypes/ExternalContentBeaverBuilder.php
@@ -60,11 +60,12 @@ class ExternalContentBeaverBuilder extends ExternalContentAbstract implements Co
         return $source;
     }
 
-    public function canHandle(string $contentType, ?int $contentId = null): bool
+    public function getSupportLevel(string $contentType, ?int $contentId = null): string
     {
-        return parent::canHandle($contentType, $contentId) &&
-            $this->contentTypeHelper->isPost($contentType) &&
-            $this->getDataFromPostMeta($contentId) !== '';
+        if ($this->contentTypeHelper->isPost($contentType) && $this->getDataFromPostMeta($contentId) !== '') {
+            return parent::getSupportLevel($contentType, $contentId);
+        }
+        return self::NOT_SUPPORTED;
     }
 
     private function extractContent(array $data): ExternalData {

--- a/inc/Smartling/ContentTypes/ExternalContentElementor.php
+++ b/inc/Smartling/ContentTypes/ExternalContentElementor.php
@@ -146,11 +146,12 @@ class ExternalContentElementor extends ExternalContentAbstract implements Conten
         return $source;
     }
 
-    public function canHandle(string $contentType, ?int $contentId = null): bool
+    public function getSupportLevel(string $contentType, ?int $contentId = null): string
     {
-        return parent::canHandle($contentType, $contentId) &&
-            $this->contentTypeHelper->isPost($contentType) &&
-            $this->getDataFromPostMeta($contentId) !== '';
+        if ($this->contentTypeHelper->isPost($contentType) && $this->getDataFromPostMeta($contentId) !== '') {
+            return parent::getSupportLevel($contentType, $contentId);
+        }
+        return self::NOT_SUPPORTED;
     }
 
     private function extractContent(array $data, string $previousPrefix = ''): ExternalData {

--- a/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
+++ b/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
@@ -43,7 +43,7 @@ class ExternalContentGravityForms extends ExternalContentAbstract implements Con
         $this->gutenbergBlockHelper = $gutenbergBlockHelper;
         $this->handler = $handler;
         $this->siteHelper = $siteHelper;
-        if (parent::canHandle(self::CONTENT_TYPE)) {
+        if (parent::getSupportLevel(self::CONTENT_TYPE)) {
             $contentEntitiesIOFactory->registerHandler(self::CONTENT_TYPE, $handler);
             $contentTypeManager->addDescriptor($contentType);
         }
@@ -55,10 +55,12 @@ class ExternalContentGravityForms extends ExternalContentAbstract implements Con
         return $source;
     }
 
-    public function canHandle(string $contentType, ?int $contentId = null): bool
+    public function getSupportLevel(string $contentType, ?int $contentId = null): string
     {
-        return parent::canHandle($contentType, $contentId) &&
-            ($contentType === self::CONTENT_TYPE || $this->contentTypeHelper->isPost($contentType));
+        if ($contentType === self::CONTENT_TYPE || $this->contentTypeHelper->isPost($contentType)) {
+            return parent::getSupportLevel($contentType, $contentId);
+        }
+        return self::NOT_SUPPORTED;
     }
 
     public function getContentFields(SubmissionEntity $submission, bool $raw): array

--- a/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
+++ b/inc/Smartling/ContentTypes/ExternalContentGravityForms.php
@@ -43,7 +43,7 @@ class ExternalContentGravityForms extends ExternalContentAbstract implements Con
         $this->gutenbergBlockHelper = $gutenbergBlockHelper;
         $this->handler = $handler;
         $this->siteHelper = $siteHelper;
-        if (parent::getSupportLevel(self::CONTENT_TYPE)) {
+        if (parent::getSupportLevel(self::CONTENT_TYPE) === self::SUPPORTED) {
             $contentEntitiesIOFactory->registerHandler(self::CONTENT_TYPE, $handler);
             $contentTypeManager->addDescriptor($contentType);
         }

--- a/inc/Smartling/ContentTypes/ExternalContentManager.php
+++ b/inc/Smartling/ContentTypes/ExternalContentManager.php
@@ -98,7 +98,7 @@ class ExternalContentManager
     public function setExternalContent(array $original, array $translation, SubmissionEntity $submission): array
     {
         foreach ($this->handlers as $handler) {
-            if ($handler->getSupportLevel($submission->getContentType(), $submission->getSourceId())) {
+            if ($handler->getSupportLevel($submission->getContentType(), $submission->getSourceId()) === ContentTypePluggableInterface::SUPPORTED) {
                 $this->getLogger()->debug("Determined support for {$handler->getPluginId()}, will try to set fields");
                 try {
                     $externalContent = $handler->setContentFields($original, $translation, $submission);

--- a/inc/Smartling/ContentTypes/ExternalContentManager.php
+++ b/inc/Smartling/ContentTypes/ExternalContentManager.php
@@ -42,7 +42,7 @@ class ExternalContentManager
                     break;
                 case ContentTypePluggableInterface::VERSION_NOT_SUPPORTED:
                     if ($handler instanceof ContentTypeModifyingInterface) {
-                        $this->getLogger()->warning("Detected not supported version for {$handler->getPluginId()}, will clear known problematic fields");
+                        $this->getLogger()->warning("Detected not supported version for {$handler->getPluginId()}, will not include known problematic fields");
                         try {
                             $source = $handler->alterContentFieldsForUpload($source);
                         } catch (\Throwable $e) {
@@ -72,7 +72,7 @@ class ExternalContentManager
     {
         $result = [];
         foreach ($this->handlers as $handler) {
-            if ($handler->getSupportLevel($contentType, $id)) {
+            if ($handler->getSupportLevel($contentType, $id) === ContentTypePluggableInterface::SUPPORTED) {
                 $this->getLogger()->debug("Determined support for {$handler->getPluginId()}, will try to get related content");
                 try {
                     $result = array_merge_recursive($result, $handler->getRelatedContent($contentType, $id));

--- a/tests/Smartling/ContentTypes/ExternalContentBeaverBuilderTest.php
+++ b/tests/Smartling/ContentTypes/ExternalContentBeaverBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Smartling\Tests\Smartling\ContentTypes;
 
 use Smartling\ContentTypes\ContentTypeHelper;
+use Smartling\ContentTypes\ContentTypePluggableInterface;
 use Smartling\ContentTypes\ExternalContentBeaverBuilder;
 use PHPUnit\Framework\TestCase;
 use Smartling\Helpers\PluginHelper;
@@ -22,8 +23,8 @@ class ExternalContentBeaverBuilderTest extends TestCase {
         $proxy->method('getPostMeta')->willReturn('', []);
         $proxy->method('get_plugins')->willReturn([$pluginPath => []]);
         $proxy->method('is_plugin_active')->willReturn(true);
-        $this->assertFalse($this->getExternalContentBeaverBuilder($proxy)->canHandle('post', 1));
-        $this->assertTrue($this->getExternalContentBeaverBuilder($proxy)->canHandle('post', 1));
+        $this->assertEquals(ContentTypePluggableInterface::NOT_SUPPORTED, $this->getExternalContentBeaverBuilder($proxy)->getSupportLevel('post', 1));
+        $this->assertEquals(ContentTypePluggableInterface::SUPPORTED, $this->getExternalContentBeaverBuilder($proxy)->getSupportLevel('post', 1));
     }
 
     /**

--- a/tests/Smartling/ContentTypes/ExternalContentElementorTest.php
+++ b/tests/Smartling/ContentTypes/ExternalContentElementorTest.php
@@ -3,6 +3,7 @@
 namespace Smartling\Tests\Smartling\ContentTypes;
 
 use Smartling\ContentTypes\ContentTypeHelper;
+use Smartling\ContentTypes\ContentTypePluggableInterface;
 use Smartling\ContentTypes\ExternalContentElementor;
 use PHPUnit\Framework\TestCase;
 use Smartling\Helpers\FieldsFilterHelper;
@@ -19,8 +20,8 @@ class ExternalContentElementorTest extends TestCase {
         $proxy->method('getPostMeta')->willReturn('', []);
         $proxy->method('get_plugins')->willReturn(['elementor/elementor.php' => []]);
         $proxy->method('is_plugin_active')->willReturn(true);
-        $this->assertFalse($this->getExternalContentElementor($proxy)->canHandle('post', 1));
-        $this->assertTrue($this->getExternalContentElementor($proxy)->canHandle('post', 1));
+        $this->assertEquals(ContentTypePluggableInterface::NOT_SUPPORTED, $this->getExternalContentElementor($proxy)->getSupportLevel('post', 1));
+        $this->assertEquals(ContentTypePluggableInterface::SUPPORTED, $this->getExternalContentElementor($proxy)->getSupportLevel('post', 1));
     }
 
     /**

--- a/tests/Smartling/ContentTypes/ExternalContentManagerTest.php
+++ b/tests/Smartling/ContentTypes/ExternalContentManagerTest.php
@@ -123,12 +123,22 @@ class ExternalContentManagerTest extends TestCase {
             unset ($value['entity']['post_content']);
             return $value;
         });
+
         $handlerUnsupportedVersion = $this->createMock(ContentTypeModifyingInterface::class);
         $handlerUnsupportedVersion->method('getSupportLevel')->willReturn(ContentTypePluggableInterface::VERSION_NOT_SUPPORTED);
         $handlerUnsupportedVersion->expects($this->never())->method('getContentFields')->willReturn(['content_4' => 'content 4']);
         $handlerUnsupportedVersion->method('getPluginId')->willReturn('content4');
         $handlerUnsupportedVersion->method('alterContentFieldsForUpload')->willReturnCallback(static function ($value) {
             unset ($value['meta']['unsupported_meta']);
+            return $value;
+        });
+
+        $handlerUnsupported = $this->createMock(ContentTypeModifyingInterface::class);
+        $handlerUnsupported->method('getSupportLevel')->willReturn(ContentTypePluggableInterface::VERSION_NOT_SUPPORTED);
+        $handlerUnsupported->expects($this->never())->method('getContentFields')->willReturn(['content_5' => 'content 5']);
+        $handlerUnsupported->method('getPluginId')->willReturn('content5');
+        $handlerUnsupported->expects($this->never())->method('alterContentFieldsForUpload')->willReturnCallback(static function ($value) {
+            unset ($value['entity']['post_title']);
             return $value;
         });
 


### PR DESCRIPTION
Root cause of issue was unsupported plugin version. Research took some time because I tried reproducing the issue. To avoid this in the future, I propose to remove content that is obviously unsuitable for translation in cases we detect an unsupported version of a plugin