### PR TITLE
add profile changes on blog removal, clean up profiles on bootstrap (WP-816)

### DIFF
--- a/inc/Smartling/Services/BlogRemovalHandler.php
+++ b/inc/Smartling/Services/BlogRemovalHandler.php
@@ -10,6 +10,7 @@ use Smartling\Submissions\SubmissionEntity;
 use Smartling\Submissions\SubmissionManager;
 use Smartling\WP\WPHookInterface;
 
+/** @noinspection PhpUnused */
 class BlogRemovalHandler implements WPHookInterface
 {
     use LoggerSafeTrait;

--- a/inc/Smartling/Services/BlogRemovalHandler.php
+++ b/inc/Smartling/Services/BlogRemovalHandler.php
@@ -27,7 +27,7 @@ class BlogRemovalHandler implements WPHookInterface
     public function register(): void
     {
         add_action('delete_blog', [$this, 'blogRemovalHandler']);
-        add_action('wp_delete_site', [$this, 'blogRemovalHandler51']);
+        add_action('wp_delete_site', [$this, 'siteRemovalHandler']);
     }
 
     /**
@@ -84,7 +84,7 @@ class BlogRemovalHandler implements WPHookInterface
         }
     }
 
-    public function blogRemovalHandler51(\WP_Site $site): void
+    public function siteRemovalHandler(\WP_Site $site): void
     {
         $this->blogRemovalHandler($site->blog_id);
     }

--- a/inc/Smartling/Services/BlogRemovalHandler.php
+++ b/inc/Smartling/Services/BlogRemovalHandler.php
@@ -86,7 +86,7 @@ class BlogRemovalHandler implements WPHookInterface
 
     public function siteRemovalHandler(\WP_Site $site): void
     {
-        $this->blogRemovalHandler($site->blog_id);
+        $this->blogRemovalHandler((int)$site->blog_id);
     }
 
     private function getSubmissions($targetBlogId): array

--- a/inc/Smartling/Settings/ConfigurationProfileEntity.php
+++ b/inc/Smartling/Settings/ConfigurationProfileEntity.php
@@ -194,7 +194,6 @@ class ConfigurationProfileEntity extends SmartlingEntityAbstract
     /**
      * Required for parent::fromArray
      * @noinspection PhpUnused
-     * @noinspection UnknownInspectionInspection
      */
     public function setOriginalBlogId(int $blogId): void
     {

--- a/inc/Smartling/Settings/SettingsManager.php
+++ b/inc/Smartling/Settings/SettingsManager.php
@@ -247,7 +247,7 @@ class SettingsManager extends EntityManagerAbstract
     public function deleteProfile(int $id): void
     {
         $configurationsTableName = $this->getDbal()->completeTableName(ConfigurationProfileEntity::getTableName());
-        $this->getDbal()->queryPrepared("delete from $configurationsTableName where id = ?", $id);
+        $this->getDbal()->queryPrepared("delete from $configurationsTableName where id = %d", $id);
     }
 
     protected function updateLabels(ConfigurationProfileEntity $entity): ConfigurationProfileEntity

--- a/inc/config/register-on-startup.yml
+++ b/inc/config/register-on-startup.yml
@@ -23,7 +23,7 @@ services:
       - [ "addService", [ "@helper.shortcode" ]]
       - [ "addService", [ "@helper.gutenberg" ]]
       - [ "addService", [ "@meta-field.processor.manager" ]]
-      - [ "addService", [ "@service.side-removal-handler"]]
+      - [ "addService", [ "@service.blog-removal-handler"]]
       - [ "addService", [ "@service.invalid-character-cleaner" ]]
       - [ "addService", [ "@wp.translation.lock" ]]
       - [ "addService", [ "@live_notification.service" ]]

--- a/inc/config/services.yml
+++ b/inc/config/services.yml
@@ -380,11 +380,12 @@ services:
     calls:
       - [ "registerProcessor", ["@post.content.processor"]]
 
-  service.side-removal-handler:
+  service.blog-removal-handler:
     class: Smartling\Services\BlogRemovalHandler
-    calls:
-      - [ "setApiWrapper", [ "@api.wrapper.with.retries" ] ]
-      - [ "setSubmissionManager", [ "@manager.submission" ] ]
+    arguments:
+      - "@api.wrapper.with.retries"
+      - "@manager.settings"
+      - "@manager.submission"
 
   service.invalid-character-cleaner:
     class: Smartling\Services\InvalidCharacterCleaner


### PR DESCRIPTION
The cause of increased warnings count is not a loop. On bootstrap, the plugin tries to get a profile list, for which it generates labels based on blog settings. If a blog does not exist, a warning is generated. 