### PR TITLE
use Smartling placeholders for shortcode detection (WP-879)

### DIFF
--- a/inc/Smartling/Helpers/PlaceholderHelper.php
+++ b/inc/Smartling/Helpers/PlaceholderHelper.php
@@ -12,6 +12,11 @@ class PlaceholderHelper
         return self::SMARTLING_PLACEHOLDER_MASK_START . $string . self::SMARTLING_PLACEHOLDER_MASK_END;
     }
 
+    public function hasPlaceholders(string $string): bool
+    {
+        return preg_match('~' . self::SMARTLING_PLACEHOLDER_MASK_START . '.+' . self::SMARTLING_PLACEHOLDER_MASK_END . '~', $string);
+    }
+
     public function removePlaceholders(string $string): string
     {
         return preg_replace('~' . self::SMARTLING_PLACEHOLDER_MASK_START . '(.*?)' . self::SMARTLING_PLACEHOLDER_MASK_END . '~', '$1', $string);

--- a/inc/Smartling/Helpers/ShortcodeHelper.php
+++ b/inc/Smartling/Helpers/ShortcodeHelper.php
@@ -6,16 +6,22 @@ use DOMElement;
 use DOMNode;
 use Smartling\Base\ExportedAPI;
 use Smartling\Helpers\EventParameters\TranslationStringFilterParameters;
+use Smartling\Settings\SettingsManager;
 
-/**
- * Class ShortcodeHelper
- *
- * @package Smartling\Helpers
- */
 class ShortcodeHelper extends SubstringProcessorHelperAbstract
 {
     private const SMARTLING_SHORTCODE_MASK_OLD = '##';
     private const SHORTCODE_SUBSTRING_NODE_NAME = 'shortcodeattribute';
+
+    public function __construct(
+        ContentSerializationHelper $contentSerializationHelper,
+        FieldsFilterHelper $fieldsFilterHelper,
+        private PlaceholderHelper $placeholderHelper,
+        SettingsManager $settingsManager,
+    ) {
+        parent::__construct($contentSerializationHelper, $settingsManager);
+        $this->setFieldsFilter($fieldsFilterHelper);
+    }
 
     /**
      * Returns a regexp for masked shortcodes
@@ -83,6 +89,9 @@ class ShortcodeHelper extends SubstringProcessorHelperAbstract
      */
     private function hasShortcodes($string)
     {
+        if ($this->placeholderHelper->hasPlaceholders($string)) {
+            return true;
+        }
         $possibleShortcodes = $this->getRegisteredShortcodes();
 
         global $shortcode_tags;

--- a/inc/Smartling/Helpers/ShortcodeHelper.php
+++ b/inc/Smartling/Helpers/ShortcodeHelper.php
@@ -18,6 +18,7 @@ class ShortcodeHelper extends SubstringProcessorHelperAbstract
         FieldsFilterHelper $fieldsFilterHelper,
         private PlaceholderHelper $placeholderHelper,
         SettingsManager $settingsManager,
+        private WordpressFunctionProxyHelper $wpProxy,
     ) {
         parent::__construct($contentSerializationHelper, $settingsManager);
         $this->setFieldsFilter($fieldsFilterHelper);
@@ -403,7 +404,7 @@ class ShortcodeHelper extends SubstringProcessorHelperAbstract
     {
         $shortcodes = array_keys($this->getShortcodeAssignments());
         try {
-            $injectedShortcodes = apply_filters(ExportedAPI::FILTER_SMARTLING_INJECT_SHORTCODE, []);
+            $injectedShortcodes = $this->wpProxy->apply_filters(ExportedAPI::FILTER_SMARTLING_INJECT_SHORTCODE, []);
             if (!is_array($injectedShortcodes)) {
                 $this->getLogger()->critical('Injected shortcodes not an array after filter ' . ExportedAPI::FILTER_SMARTLING_INJECT_SHORTCODE . '. This is most likely due to an error outside of the plugins code.');
             }
@@ -429,7 +430,7 @@ class ShortcodeHelper extends SubstringProcessorHelperAbstract
     {
         global $shortcode_tags;
 
-        return $shortcode_tags;
+        return $shortcode_tags ?? [];
     }
 
     /**

--- a/inc/config/services.yml
+++ b/inc/config/services.yml
@@ -416,9 +416,9 @@ services:
     class: Smartling\Helpers\ShortcodeHelper
     arguments:
       - "@content-serialization.helper"
+      - "@fields-filter.helper"
+      - "@helper.placeholders"
       - "@manager.settings"
-    calls:
-      - [ "setFieldsFilter", [ "@fields-filter.helper" ]]
 
   default.meta-field-processor:
     class: Smartling\Helpers\MetaFieldProcessor\DefaultMetaFieldProcessor

--- a/inc/config/services.yml
+++ b/inc/config/services.yml
@@ -419,6 +419,7 @@ services:
       - "@fields-filter.helper"
       - "@helper.placeholders"
       - "@manager.settings"
+      - "@wp.proxy"
 
   default.meta-field-processor:
     class: Smartling\Helpers\MetaFieldProcessor\DefaultMetaFieldProcessor

--- a/tests/MetadataSerializerTest.php
+++ b/tests/MetadataSerializerTest.php
@@ -219,6 +219,9 @@ class MetadataSerializerTest extends TestCase
     {
         $wpProxy = $this->createMock(WordpressFunctionProxyHelper::class);
         $wpProxy->method('maybe_unserialize')->willReturnCallback(function ($original) {
+            if (!is_string($original)) {
+                return $original;
+            }
             try {
                 return unserialize($original) ?: $original;
             } catch (\Throwable) {

--- a/tests/Smartling/Helpers/PlaceholderHelperTest.php
+++ b/tests/Smartling/Helpers/PlaceholderHelperTest.php
@@ -6,20 +6,64 @@ use Smartling\Helpers\PlaceholderHelper;
 use PHPUnit\Framework\TestCase;
 
 class PlaceholderHelperTest extends TestCase {
-    public function testRemovePlaceholders()
+    /**
+     * @dataProvider hasPlaceholdersDataProvider
+     */
+    public function testHasPlaceholders(string $string, bool $expected)
     {
-        $x = new PlaceholderHelper();
-        $this->assertEquals('', $x->removePlaceholders(null ?? ''));
-        $this->assertEquals('', $x->removePlaceholders(''));
-        $this->assertEquals('#Content', $x->removePlaceholders(PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . '#Content' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END));
-        $this->assertEquals('#post_title #separator_sa #site_title Post title edited', $x->removePlaceholders(
-            PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . '#post_title #separator_sa #site_title' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END .
-            ' Post title edited'
-        ));
-        $this->assertEquals('#post_excerpt Translation content in the middle #separator_sa', $x->removePlaceholders(
-            PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . '#post_excerpt' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END .
-            ' Translation content in the middle ' .
-            PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . '#separator_sa' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END
-        ));
+        $this->assertEquals($expected, (new PlaceholderHelper())->hasPlaceholders($string));
+    }
+
+    public function hasPlaceholdersDataProvider(): array
+    {
+        return [
+            [
+                '',
+                false,
+            ],
+            [
+                PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . '#Content' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END,
+                true,
+            ],
+            [
+                PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . 'test1' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END
+                . ' test2 ' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . 'test3' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END,
+                true,
+            ]
+        ];
+    }
+
+
+    /**
+     * @dataProvider removePlaceholdersDataProvider
+     */
+    public function testRemovePlaceholders(string $string, string $expected)
+    {
+        $this->assertEquals($expected, (new PlaceholderHelper())->removePlaceholders($string));
+    }
+
+    public function removePlaceholdersDataProvider(): array
+    {
+        return [
+            [
+                '',
+                '',
+            ],
+            [
+                PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . '#Content' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END,
+                '#Content',
+            ],
+            [
+                PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . '#post_title #separator_sa #site_title' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END .
+                ' Post title edited',
+                '#post_title #separator_sa #site_title Post title edited',
+            ],
+            [
+                PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . '#post_excerpt' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END .
+                ' Translation content in the middle ' .
+                PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_START . '#separator_sa' . PlaceholderHelper::SMARTLING_PLACEHOLDER_MASK_END,
+                '#post_excerpt Translation content in the middle #separator_sa',
+            ],
+        ];
     }
 }

--- a/tests/Smartling/Helpers/ShortcodeHelperTest.php
+++ b/tests/Smartling/Helpers/ShortcodeHelperTest.php
@@ -4,10 +4,13 @@ namespace Smartling\Tests\Smartling\Helpers;
 
 use DOMDocument;
 use PHPUnit\Framework\TestCase;
+use Smartling\DbAl\Migrations\Migration160125;
 use Smartling\Helpers\ContentSerializationHelper;
 use Smartling\Helpers\EventParameters\TranslationStringFilterParameters;
+use Smartling\Helpers\FieldsFilterHelper;
 use Smartling\Helpers\PlaceholderHelper;
 use Smartling\Helpers\ShortcodeHelper;
+use Smartling\Helpers\WordpressFunctionProxyHelper;
 use Smartling\Settings\SettingsManager;
 use Smartling\Tests\Traits\InvokeMethodTrait;
 
@@ -78,10 +81,7 @@ class ShortcodeHelperTest extends TestCase
 
         $node = $nodelist->item(0);
 
-        $helper = new ShortcodeHelper(
-            $this->createMock(ContentSerializationHelper::class),
-            $this->createMock(SettingsManager::class),
-        );
+        $helper = $this->getShortcodeHelper();
 
         $this->invokeMethod($helper, 'extractTranslations', [$node]);
 
@@ -105,6 +105,24 @@ class ShortcodeHelperTest extends TestCase
         ];
 
         self::assertEquals($expectedTranslations, $this->getProperty($helper, 'blockAttributes'));
+    }
+
+    public function testProcessTranslation()
+    {
+        $wpProxy = $this->createMock(WordpressFunctionProxyHelper::class);
+        $wpProxy->method('apply_filters')->willReturnArgument(1);
+
+        $xml = new DOMDocument('1.0', 'UTF-8');
+        $xml->loadXML('<test><string name="entity/post_content"><shortcodeattribute shortcode="custom-shortcode" hash="d3f06f0519040b5d46e6160b1a1e4d71" name="name"><![CDATA[split-content-partner-logos]]></shortcodeattribute><![CDATA[<div>#sl-start#[custom-shortcode name="split-content-partner-logos"]#sl-end#</div>]]></string></test>');
+
+        $parameters = new TranslationStringFilterParameters();
+        $parameters->setDom($xml);
+        $parameters->setNode((new \DOMXPath($xml))->query('/test/string')->item(0));
+
+        $this->assertEquals(
+            '<div>[custom-shortcode name="split-content-partner-logos"]</div>',
+            $this->getShortcodeHelper($wpProxy)->processTranslation($parameters)->getNode()->nodeValue,
+        );
     }
 
     /**
@@ -367,11 +385,17 @@ class ShortcodeHelperTest extends TestCase
         return $data;
     }
 
-    private function getShortcodeHelper(): ShortcodeHelper
+    private function getShortcodeHelper(WordpressFunctionProxyHelper $wpProxy = null): ShortcodeHelper
     {
+        if ($wpProxy === null) {
+            $wpProxy = $this->createMock(WordpressFunctionProxyHelper::class);
+        }
         return new ShortcodeHelper(
             $this->createMock(ContentSerializationHelper::class),
+            $this->createMock(FieldsFilterHelper::class),
+            new PlaceholderHelper(),
             $this->createMock(SettingsManager::class),
+            $wpProxy,
         );
     }
 }

--- a/tests/Smartling/Helpers/ShortcodeHelperTest.php
+++ b/tests/Smartling/Helpers/ShortcodeHelperTest.php
@@ -4,7 +4,6 @@ namespace Smartling\Tests\Smartling\Helpers;
 
 use DOMDocument;
 use PHPUnit\Framework\TestCase;
-use Smartling\DbAl\Migrations\Migration160125;
 use Smartling\Helpers\ContentSerializationHelper;
 use Smartling\Helpers\EventParameters\TranslationStringFilterParameters;
 use Smartling\Helpers\FieldsFilterHelper;


### PR DESCRIPTION
The connector uses the shortcodes that are registered in WP or added in fine-tuning section. It appears the fine-tuning was not set up, as when testing locally with the proper setup, no `#sl-start#` or `#sl-end#` tags appear. Without setting up the fine-tuning, the result is as experienced by the reporter. I'll update the documentation accordingly, but this PR could also help to resolve the issue. The plugin only wraps registered shortcodes in said tags, and the potential for false-positives is quite low, I believe.

I could think of no other way to determine shortcodes presence, as a string that looks like a WP shortcode `[text]` might as well be plain text that is meant for translation.