### PR TITLE
force register post type (WP-892)

### DIFF
--- a/inc/Smartling/Services/CustomPostTypeDebugService.php
+++ b/inc/Smartling/Services/CustomPostTypeDebugService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Smartling\Services;
+
+use Smartling\Base\ExportedAPI;
+use Smartling\Bootstrap;
+use Smartling\ContentTypes\CustomPostType;
+use Smartling\Helpers\LoggerSafeTrait;
+use Smartling\WP\WPHookInterface;
+
+class CustomPostTypeDebugService implements WPHookInterface {
+
+    use LoggerSafeTrait;
+
+    private const SF_PRESS_RELEASE = 'sf_press_release';
+
+    public function register(): void
+    {
+        add_filter(ExportedAPI::FILTER_SMARTLING_REGISTER_CUSTOM_POST_TYPE, [$this, 'debugPostTypes']);
+    }
+
+    public function debugPostTypes(array $postTypes): array
+    {
+        $debugInfo = [];
+        foreach ($postTypes as $postType) {
+            $debugInfo[] = $postType['type']['identifier'] ?? '*invalid* (' . json_encode($postType) . ')';
+        }
+        $this->getLogger()->debug("Post types registered: " . implode(', ', $debugInfo));
+        if (!in_array(self::SF_PRESS_RELEASE, $debugInfo, true)) {
+            $this->getLogger()->debug(sprintf("No %s in registered post types", self::SF_PRESS_RELEASE));
+            global $wp_post_types;
+            if (array_key_exists(self::SF_PRESS_RELEASE, $wp_post_types)) {
+                $this->getLogger()->debug("Post type exists in globals, but not registered");
+            }
+            $di = Bootstrap::getContainer();
+            CustomPostType::registerCustomType($di, [
+                "type" =>
+                    [
+                        'identifier' => self::SF_PRESS_RELEASE,
+                        'widget'     => [
+                            'visible' => true,
+                        ],
+                        'visibility' => [
+                            'submissionBoard' => true,
+                            'bulkSubmit' => true,
+                        ],
+                    ],
+            ]);
+        }
+        return $postTypes;
+    }
+}

--- a/inc/config/register-on-startup.yml
+++ b/inc/config/register-on-startup.yml
@@ -1,5 +1,7 @@
 parameters:
 services:
+  service.post.type.debug:
+    class: Smartling\Services\CustomPostTypeDebugService
   manager.register:
     class: Smartling\StartupRegisterManager
     calls:
@@ -30,3 +32,4 @@ services:
       - [ "addService", [ "@content.relations.handler"]]
       - [ "addService", [ "@duplicate.submissions.cleaner"]]
       - [ "addService", [ "@service.filter-ui" ]]
+      - [ "addService", [ "@service.post.type.debug" ]]


### PR DESCRIPTION
Since it's not possible to determine the reason of post type some times not being registered, we'll try to force register post type handler.
This must not be released for general availability.