### PR TITLE
fix batch creation error (WP-907)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "3.9.8",
+  "version": "3.9.9",
   "description": "",
   "type": "wordpress-plugin",
   "repositories": [

--- a/inc/Smartling/Services/ContentRelationsDiscoveryService.php
+++ b/inc/Smartling/Services/ContentRelationsDiscoveryService.php
@@ -302,7 +302,7 @@ class ContentRelationsDiscoveryService
         $this->uploadQueueManager->enqueue($queueIds, $this->apiWrapper->createBatch(
             $profile,
             $jobInfo->getJobUid(),
-            array_unique($fileUris),
+            array_values(array_unique($fileUris)),
             $job->isAuthorize(),
         ));
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 6.4.1
 Requires PHP: 8.0
-Stable tag: 3.9.8
+Stable tag: 3.9.9
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 3.9.9 =
+* Fixed submissions not being uploaded when related assets list has multiple entries that point to the same content
+
 = 3.9.8 =
 * Fixed extra slashes being added in Gutenberg block attributes that had quotes after translation
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -11,7 +11,7 @@ use Smartling\RestApi;
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           3.9.8
+ * Version:           3.9.9
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+


### PR DESCRIPTION
`array_unique()`, when removing an element that is not the last from an array turns a list (json encoded as `['a', 'b']`) into a map (json encoded as `{"0":"a","2":"b"}`)