### PR TITLE
add support for ACF `relation` field groups (WP-911)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "3.9.10",
+  "version": "3.9.11",
   "description": "",
   "type": "wordpress-plugin",
   "repositories": [

--- a/inc/Smartling/Services/ContentRelationsDiscoveryService.php
+++ b/inc/Smartling/Services/ContentRelationsDiscoveryService.php
@@ -711,7 +711,13 @@ class ContentRelationsDiscoveryService
                 AcfDynamicSupport::REFERENCED_TYPE_POST,
             ], true)) {
                 $referencedValue = $block->getAttributes()['data'][substr($attribute, 1)] ?? null;
-                if (is_numeric($referencedValue)) {
+                if (is_array($referencedValue)) {
+                    foreach ($referencedValue as $innerReferencedValue) {
+                        if (is_numeric($innerReferencedValue)) {
+                            $result[] = (int)$innerReferencedValue;
+                        }
+                    }
+                } elseif (is_numeric($referencedValue)) {
                     $result[] = (int)$referencedValue;
                 }
             }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 6.4.1
 Requires PHP: 8.0
-Stable tag: 3.9.10
+Stable tag: 3.9.11
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 3.9.11 =
+* Added related content detection for ACF field groups with group type `relation`
+
 = 3.9.10 =
 * Added logging of registered post types
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -11,7 +11,7 @@ use Smartling\RestApi;
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           3.9.10
+ * Version:           3.9.11
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/Services/ContentRelationsDiscoveryServiceTest.php
+++ b/tests/Services/ContentRelationsDiscoveryServiceTest.php
@@ -771,10 +771,7 @@ namespace Smartling\Tests\Services {
                 $this->createMock(ContentHelper::class),
                 $this->createMock(SettingsManager::class),
                 $this->createMock(SubmissionManager::class),
-                null,
-                null,
-                null,
-                $acfDynamicSupport
+                acfDynamicSupport: $acfDynamicSupport,
             );
 
             $this->assertEquals([$attachmentId], $x->getReferencesFromAcf(new GutenbergBlock('acf/gallery-carousel', [
@@ -799,10 +796,7 @@ namespace Smartling\Tests\Services {
                 $this->createMock(ContentHelper::class),
                 $this->createMock(SettingsManager::class),
                 $this->createMock(SubmissionManager::class),
-                null,
-                null,
-                null,
-                $acfDynamicSupport
+                acfDynamicSupport: $acfDynamicSupport,
             );
 
             $this->assertEquals([22892, 22893], $x->getReferencesFromAcf(new GutenbergBlock('acf/gallery-carousel', [

--- a/tests/Services/ContentRelationsDiscoveryServiceTest.php
+++ b/tests/Services/ContentRelationsDiscoveryServiceTest.php
@@ -67,7 +67,7 @@ namespace Smartling\Tests\Services {
     use Smartling\Tuner\MediaAttachmentRulesManager;
     use Smartling\Vendor\Smartling\AuditLog\Params\CreateRecordParameters;
 
-    class ContentRelationDiscoveryServiceTest extends TestCase
+    class ContentRelationsDiscoveryServiceTest extends TestCase
     {
         private ?\Exception $exception = null;
         protected function setUp(): void
@@ -750,9 +750,21 @@ namespace Smartling\Tests\Services {
             $irrelevantKey = 'field_5d5db4597e812';
 
             $acfDynamicSupport = $this->createMock(AcfDynamicSupport::class);
-            $acfDynamicSupport->expects($this->exactly(2))->method('getReferencedTypeByKey')
-                ->withConsecutive([$attachmentKey], [$irrelevantKey])
-                ->willReturnOnConsecutiveCalls(AcfDynamicSupport::REFERENCED_TYPE_MEDIA, AcfDynamicSupport::REFERENCED_TYPE_NONE);
+            $matcher = $this->exactly(2);
+            $acfDynamicSupport->expects($matcher)->method('getReferencedTypeByKey')
+                ->willReturnCallback(function ($key) use ($attachmentKey, $irrelevantKey, $matcher) {
+                    switch ($matcher->getInvocationCount()) {
+                        case 1:
+                            $this->assertEquals($attachmentKey, $key);
+
+                            return AcfDynamicSupport::REFERENCED_TYPE_MEDIA;
+                        case 2:
+                            $this->assertEquals($irrelevantKey, $key);
+
+                            return AcfDynamicSupport::REFERENCED_TYPE_NONE;
+                    }
+                    $this->fail('Expected two calls');
+                });
 
             $x = $this->getContentRelationDiscoveryService(
                 $this->createMock(ApiWrapper::class),
@@ -773,6 +785,31 @@ namespace Smartling\Tests\Services {
                     '_media_0_image' => $attachmentKey,
                     'media' => 1,
                     '_media' => $irrelevantKey,
+                ]
+            ], [], '', [])));
+        }
+
+        public function testAcfReferencesArraysDetected() {
+            $acfDynamicSupport = $this->createMock(AcfDynamicSupport::class);
+            $acfDynamicSupport->expects($this->once())->method('getReferencedTypeByKey')
+                ->willReturn(AcfDynamicSupport::REFERENCED_TYPE_POST);
+
+            $x = $this->getContentRelationDiscoveryService(
+                $this->createMock(ApiWrapper::class),
+                $this->createMock(ContentHelper::class),
+                $this->createMock(SettingsManager::class),
+                $this->createMock(SubmissionManager::class),
+                null,
+                null,
+                null,
+                $acfDynamicSupport
+            );
+
+            $this->assertEquals([22892, 22893], $x->getReferencesFromAcf(new GutenbergBlock('acf/gallery-carousel', [
+                'name' => 'acf/gallery-carousel',
+                'data' => [
+                    'testimonials_slider' => ["22892", "22893"],
+                    '_testimonials_slider' => 'field_66c32d42be1aa',
                 ]
             ], [], '', [])));
         }

--- a/tests/Services/ContentRelationsDiscoveryServiceTest.php
+++ b/tests/Services/ContentRelationsDiscoveryServiceTest.php
@@ -800,7 +800,7 @@ namespace Smartling\Tests\Services {
             );
 
             $this->assertEquals([22892, 22893], $x->getReferencesFromAcf(new GutenbergBlock('acf/gallery-carousel', [
-                'name' => 'acf/gallery-carousel',
+                'name' => 'acf/testimonial-slider',
                 'data' => [
                     'testimonials_slider' => ["22892", "22893"],
                     '_testimonials_slider' => 'field_66c32d42be1aa',


### PR DESCRIPTION
There is in fact an improvement that comes out of the issue described, two other issues are config and/or other plugins related