### PR TITLE
add option to skip ACF filter removal (WP-913)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "3.9.14",
+  "version": "3.9.15",
   "description": "",
   "type": "wordpress-plugin",
   "repositories": [

--- a/inc/Smartling/Bootstrap.php
+++ b/inc/Smartling/Bootstrap.php
@@ -191,6 +191,7 @@ class Bootstrap
         GlobalSettingsManager::setAddSlashesBeforeSavingContent($data[GlobalSettingsManager::SETTING_ADD_SLASHES_BEFORE_SAVING_CONTENT]);
         GlobalSettingsManager::setAddSlashesBeforeSavingMeta($data[GlobalSettingsManager::SETTING_ADD_SLASHES_BEFORE_SAVING_META]);
         GlobalSettingsManager::setCustomDirectives($data[GlobalSettingsManager::SETTING_CUSTOM_DIRECTIVES]);
+        GlobalSettingsManager::setRemoveAcfParseSaveBlocksFilter($data[GlobalSettingsManager::SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER]);
         GlobalSettingsManager::setSkipSelfCheck((int)$data['selfCheckDisabled']);
         GlobalSettingsManager::setDisableLogging((int)$data['disableLogging']);
         GlobalSettingsManager::setLogFileSpec($data['loggingPath']);

--- a/inc/Smartling/Services/GlobalSettingsManager.php
+++ b/inc/Smartling/Services/GlobalSettingsManager.php
@@ -205,6 +205,23 @@ class GlobalSettingsManager
         }
     }
 
+    public const SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER = 'smartling_remove_acf_parse_save_blocks_filter';
+    public const SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER_DEFAULT = "1";
+
+    public static function isRemoveAcfParseSaveBlocksFilter(): bool
+    {
+        return SimpleStorageHelper::get(self::SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER, self::SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER_DEFAULT) === "1";
+    }
+
+    public static function setRemoveAcfParseSaveBlocksFilter(string $value): void
+    {
+        if ($value === self::SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER_DEFAULT) {
+            SimpleStorageHelper::drop(self::SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER);
+        } else {
+            SimpleStorageHelper::set(self::SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER, $value);
+        }
+    }
+
     public const SETTING_ADD_SLASHES_BEFORE_SAVING_CONTENT = 'smartling_add_slashes_before_saving_content';
     public const SETTING_ADD_SLASHES_BEFORE_SAVING_CONTENT_DEFAULT = "1";
 

--- a/inc/Smartling/WP/View/ConfigurationProfiles.php
+++ b/inc/Smartling/WP/View/ConfigurationProfiles.php
@@ -267,6 +267,26 @@ $data = $this->getViewData();
                         </td>
                     </tr>
                     <tr>
+                        <th><label for="<?= GlobalSettingsManager::SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER?>"><?= __('Remove ACF parse save blocks filter')?></label></th>
+                        <td>
+                            <?=
+                            HtmlTagGeneratorHelper::tag(
+                                'select',
+                                HtmlTagGeneratorHelper::renderSelectOptions(
+                                    GlobalSettingsManager::isRemoveAcfParseSaveBlocksFilter() ? 1 : 0,
+                                    [
+                                        0 => 'No',
+                                        1 => 'Yes',
+                                    ]),
+                                [
+                                    'id' => GlobalSettingsManager::SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER,
+                                    'name' => GlobalSettingsManager::SETTING_REMOVE_ACF_PARSE_SAVE_BLOCKS_FILTER,
+                                ]
+                            )
+                            ?>
+                        </td>
+                    </tr>
+                    <tr>
                         <th><label for="<?= GlobalSettingsManager::SETTING_CUSTOM_DIRECTIVES?>"><a href="https://help.smartling.com/hc/en-us/articles/360008000893-XML#directives"><?= __('Custom directives')?></a><?= __('. The connector will wrap each line from this text area into inline directives') ?><pre>&lt;!-- smartling.%%line%% --&gt;</pre><br><?= __('Invalid directives WILL BREAK PROCESSING.')?></label></th>
                         <td>
                             <textarea id="<?= GlobalSettingsManager::SETTING_CUSTOM_DIRECTIVES?>"><?= GlobalSettingsManager::getCustomDirectives()?></textarea>

--- a/js/configuration-profile-form.js
+++ b/js/configuration-profile-form.js
@@ -25,6 +25,7 @@
                     'smartling_add_slashes_before_saving_content': $('#smartling_add_slashes_before_saving_content').val(),
                     'smartling_add_slashes_before_saving_meta': $('#smartling_add_slashes_before_saving_meta').val(),
                     'smartling_custom_directives': $('#smartling_custom_directives').val(),
+                    'smartling_remove_acf_parse_save_blocks_filter': $('#smartling_remove_acf_parse_save_blocks_filter').val(),
                     'selfCheckDisabled': $('#selfCheckDisabled').val(),
                     'disableLogging': $('#disableLogging').val(),
                     'loggingPath': $('#loggingPath').val(),

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 6.6.2
 Requires PHP: 8.0
-Stable tag: 3.9.14
+Stable tag: 3.9.15
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 3.9.15 =
+* Add expert setting to skip ACF filter `acf_parse_save_blocks` removal. Defaults to on.
+
 = 3.9.14 =
 * Remove excessive logging
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -11,7 +11,7 @@ use Smartling\RestApi;
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           3.9.14
+ * Version:           3.9.15
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+

--- a/tests/Mocks/WordpressFunctionsMockHelper.php
+++ b/tests/Mocks/WordpressFunctionsMockHelper.php
@@ -233,6 +233,7 @@ namespace {
         if (!function_exists('remove_action')) {
             function remove_action($tag, $function_to_remove, $priority = 10)
             {
+                return false;
             }
         }
 


### PR DESCRIPTION
Escaping and slashing in the connector is fine.
The issue seems to be similar to an unsolved post from a long ago (https://support.advancedcustomfields.com/forums/topic/backslashes-being-added-to-page-post-content/)
This option might not solve the issue, but we'll have more info for the next iteration.