### PR TITLE
clear Elementor built-in documents cache after saving meta (WP-938)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smartling/wordpress-connector",
   "license": "GPL-2.0-or-later",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "",
   "type": "wordpress-plugin",
   "repositories": [

--- a/inc/Smartling/ContentTypes/Elementor/DocumentsManagerWrapper.php
+++ b/inc/Smartling/ContentTypes/Elementor/DocumentsManagerWrapper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Smartling\ContentTypes\Elementor;
+
+use Elementor\Core\Documents_Manager;
+
+class DocumentsManagerWrapper extends Documents_Manager
+{
+    /**
+     * @noinspection MagicMethodsValidityInspection
+     * @noinspection PhpMissingParentConstructorInspection
+     * Parent constructor not called intentionally
+     */
+    public function __construct(private Documents_Manager $documentsManager) {
+    }
+
+    public function getManagerWithoutDocuments(): Documents_Manager
+    {
+        $this->documentsManager->documents = [];
+        return $this->documentsManager;
+    }
+}

--- a/inc/Smartling/ContentTypes/Elementor/DocumentsManagerWrapper.php
+++ b/inc/Smartling/ContentTypes/Elementor/DocumentsManagerWrapper.php
@@ -9,9 +9,9 @@ class DocumentsManagerWrapper extends Documents_Manager
     /**
      * @noinspection MagicMethodsValidityInspection
      * @noinspection PhpMissingParentConstructorInspection
-     * Parent constructor not called intentionally
      */
     public function __construct(private Documents_Manager $documentsManager) {
+        // Parent constructor not called intentionally
     }
 
     public function getManagerWithoutDocuments(): Documents_Manager

--- a/inc/Smartling/ContentTypes/ExternalContentElementor.php
+++ b/inc/Smartling/ContentTypes/ExternalContentElementor.php
@@ -5,6 +5,7 @@ namespace Smartling\ContentTypes;
 use Elementor\Core\Documents_Manager;
 use ElementorPro\Plugin;
 use Smartling\Base\ExportedAPI;
+use Smartling\ContentTypes\Elementor\DocumentsManagerWrapper;
 use Smartling\ContentTypes\Elementor\ElementFactory;
 use Smartling\Extensions\Pluggable;
 use Smartling\Helpers\ArrayHelper;
@@ -97,7 +98,7 @@ class ExternalContentElementor extends ExternalContentAbstract implements Conten
 
     public function removeUntranslatableFieldsForUpload(array $source, SubmissionEntity $submission): array
     {
-        if (array_key_exists(self::META_FIELD_NAME, $source['meta'] ?? [])) {
+        if ($this->getSupportLevel($submission->getContentType(), $submission->getSourceId()) !== Pluggable::NOT_SUPPORTED) {
             $this->getLogger()->info('Detected elementor data, removing post content and elementor related meta fields');
             foreach (array_merge_recursive(
                 ['meta' => array_merge($this->copyFields, [self::META_CONDITIONS_NAME])],
@@ -244,7 +245,7 @@ class ExternalContentElementor extends ExternalContentAbstract implements Conten
     private function getDocumentsManager(): ?Documents_Manager
     {
         if (class_exists(Plugin::class)) {
-            return Plugin::elementor()->documents;
+            return (new DocumentsManagerWrapper(Plugin::elementor()->documents))->getManagerWithoutDocuments();
         }
         $documentsManagerPath = WP_PLUGIN_DIR . '/elementor/core/documents-manager.php';
         if (file_exists($documentsManagerPath)) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation, localization, localisation, translate, multilingual, smartlin
 Requires at least: 5.5
 Tested up to: 6.6.2
 Requires PHP: 8.0
-Stable tag: 3.11.7
+Stable tag: 3.12.1
 License: GPLv2 or later
 
 Translate content in WordPress quickly and seamlessly with Smartling, the industry-leading Translation Management System.
@@ -62,6 +62,9 @@ Additional information on the Smartling Connector for WordPress can be found [he
 3. Track translation status within WordPress from the Submissions Board. View overall progress of submitted translation requests as well as resend updated content.
 
 == Changelog ==
+= 3.12.1 =
+* Fixed Elementor Templates type mismatch after translation or cloning with Elementor Pro
+
 = 3.12.0 =
 * Added ACF field group synchronization between configured sites on save.
 

--- a/smartling-connector.php
+++ b/smartling-connector.php
@@ -11,7 +11,7 @@ use Smartling\RestApi;
  * Plugin Name:       Smartling Connector
  * Plugin URI:        https://www.smartling.com/products/automate/integrations/wordpress/
  * Description:       Integrate your WordPress site with Smartling to upload your content and download translations.
- * Version:           3.12.0
+ * Version:           3.12.1
  * Author:            Smartling
  * Author URI:        https://www.smartling.com
  * License:           GPL-2.0+


### PR DESCRIPTION
The issue occurred in the following sequence of events:

1. our plugin saves the post content
2. Elementor hook processes content, looks at metadata (there is none), caches the template type internally as the first available type (loop-item)
3. our plugin saves metadata
4. if Elementor elements are present in template, our plugin calls Elementor after save hook, but the template type there is read from cache instead of metadata and persists

Refactored Elementor elements present check and added a wrapper to clear Elementor Documents_Manager internal cache