### PR TITLE
Fixed unclosed tag inside ContentEditJob view (WP-1004)

### DIFF
--- a/inc/Smartling/WP/View/ContentEditJob.php
+++ b/inc/Smartling/WP/View/ContentEditJob.php
@@ -229,7 +229,7 @@ if (!$isBulkSubmitPage) : ?>
 
             </div>
 
-            <?php if ($needWrapper) : ?>
+            <?php if ($needWrapper && false) : ?>
         </div>
     </div>
 </div>

--- a/inc/Smartling/WP/View/ContentEditJob.php
+++ b/inc/Smartling/WP/View/ContentEditJob.php
@@ -234,7 +234,7 @@ if (!$isBulkSubmitPage) : ?>
     </div>
 </div>
 <?php endif; ?>
-
+</div>
 
 <?php
 $id       = 0;


### PR DESCRIPTION
Noticed the issue with this specific postbox in the editor: when it's closed, all other postbox sections below it were refusing to open. After looking at the source code, noticed that this element was added when new React UI version of the view was implemented:

https://github.com/Smartling/wordpress-localization-plugin/blob/f02eb5fdaf24a0b45f4cc8c320981887b1146847/inc/Smartling/WP/View/ContentEditJob.php#L70

But, there was no closing tag for it anywhere below. You can notice that by looking at the original commit:

https://github.com/Smartling/wordpress-localization-plugin/commit/ff6b5258ec154eda8132e4c0f352fc8cddf11665#diff-61197ae0879f9a97b254300aa7482aaa977b5ee32692e0550e85c4806739d652R71

I assume it was meant to be added just to hide the previous `.job-wizard` element. So I added the closing tag for it.

---

As for the second commit — it fixes the possibility where this hidden wizard element was creating 3 additional closing tags. In the same commit opening wrapper tags were disabled by `&& false` condition:

https://github.com/Smartling/wordpress-localization-plugin/blob/f02eb5fdaf24a0b45f4cc8c320981887b1146847/inc/Smartling/WP/View/ContentEditJob.php#L94-L98

But at the same time, this was not done for the closing tags condition:

https://github.com/Smartling/wordpress-localization-plugin/blob/f02eb5fdaf24a0b45f4cc8c320981887b1146847/inc/Smartling/WP/View/ContentEditJob.php#L232-L236

As a fix, I just added the same `&& false` condition into the second case, but perhaps it would be better to just remove these wrapper conditions completely.